### PR TITLE
Added first version of code to retrieve zookeeper connection string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,7 @@ dependencies = [
  "stackable-operator",
  "strum",
  "strum_macros",
+ "thiserror",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "8f8cb5d814eb646a863c4f24978cff2880c4be96ad8cde2c0f0678732902e271"
 
 [[package]]
 name = "async-trait"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589652ce7ccb335d1e7ecb3be145425702b290dbcb7029bbeaae263fc1d87b48"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,9 +1084,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -1228,6 +1228,19 @@ name = "rstest"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5056bc1e7cfd438570e8292ef9512774b1d0afc8a50d683fda0ebe74f6233cc6"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rstest"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b961ca336c5632e93880ee91b3ca879f1499b835daa74dd726809f6196320b7f"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -1544,7 +1557,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kube-runtime",
- "rstest",
+ "rstest 0.8.0",
  "schemars",
  "semver",
  "serde",
@@ -1567,7 +1580,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kube-runtime",
- "rstest",
+ "rstest 0.7.0",
  "serde",
  "serde_json",
  "stackable-operator",
@@ -1618,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.67"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
+checksum = "ad184cc9470f9117b2ac6817bfe297307418819ba40552f9b3846f05c33d5373"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+dependencies = [
+ "unindent",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,16 +1540,20 @@ dependencies = [
 name = "stackable-zookeeper-crd"
 version = "0.1.0"
 dependencies = [
+ "indoc",
  "k8s-openapi",
  "kube",
  "kube-runtime",
+ "rstest",
  "schemars",
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "stackable-operator",
  "strum",
  "strum_macros",
+ "tracing",
 ]
 
 [[package]]
@@ -1935,6 +1948,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "untrusted"

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The Initial Developer of parts of the code in util::is_valid_zookeeper_path
+was the Apache Software Foundation (http://www.apache.org/).
+The code has been copied from:
+https://github.com/apache/zookeeper/blob/release-3.7.0/zookeeper-server/src/main/java/org/apache/zookeeper/common/PathUtils.java#L41
+and adapted to this project by Stackable GmbH.
+The code was originally licensed under the Apache License Version 2.0,
+a copy of which can be obtained at http://www.apache.org/licenses/LICENSE-2.0

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1"
 [dev-dependencies]
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
 indoc = "1.0"
-rstest = "0.7"
+rstest = "0.8"
 serde_yaml = "0.8"
 
 [features]

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1"
 strum = "0.20"
 strum_macros = "0.20"
 tracing = "0.1"
+thiserror = "1"
 
 [dev-dependencies]
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -16,9 +16,13 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 strum = "0.20"
 strum_macros = "0.20"
+tracing = "0.1"
 
 [dev-dependencies]
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
+indoc = "1.0"
+rstest = "0.7"
+serde_yaml = "0.8"
 
 [features]
 default = ["native-tls"]

--- a/crd/src/error.rs
+++ b/crd/src/error.rs
@@ -1,0 +1,28 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Illegal value [{chroot}] provided for ZooKeeper chroot: {message}")]
+    IllegalChroot { chroot: String, message: String },
+
+    #[error("Pod has no hostname assignment, this is most probably a transitive failure and should be retried: [{pod}]")]
+    PodWithoutHostname { pod: String },
+
+    #[error("Pod [{pod}] is missing the following required labels: [{labels:?}]")]
+    PodMissingLabels { pod: String, labels: Vec<String> },
+
+    #[error("Got object with no name from Kubernetes, this should not happen, please open a ticket for this with the reference: [{reference}]")]
+    ObjectWithoutName { reference: String },
+
+    #[error("Kubernetes reported error: {source}")]
+    KubeError {
+        #[from]
+        source: kube::Error,
+    },
+
+    #[error("Operator Framework reported error: {source}")]
+    OperatorFrameworkError {
+        #[from]
+        source: stackable_operator::error::Error,
+    },
+}
+
+pub type ZookeeperOperatorResult<T> = std::result::Result<T, Error>;

--- a/crd/src/error.rs
+++ b/crd/src/error.rs
@@ -1,7 +1,10 @@
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Illegal value [{chroot}] provided for ZooKeeper chroot: {message}")]
-    IllegalChroot { chroot: String, message: String },
+    #[error("Illegal ZooKeeper path [{path}]: {errors:?}")]
+    IllegalZookeeperPath { path: String, errors: Vec<String> },
+
+    #[error("Illegal znode [{znode}]: {reason}")]
+    IllegalZnode { znode: String, reason: String },
 
     #[error("Pod has no hostname assignment, this is most probably a transitive failure and should be retried: [{pod}]")]
     PodWithoutHostname { pod: String },

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -1,3 +1,4 @@
+mod error;
 mod util;
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -1,4 +1,4 @@
-mod error;
+pub mod error;
 pub mod util;
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -1,9 +1,15 @@
+mod util;
+
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use semver::{SemVerError, Version};
 use serde::{Deserialize, Serialize};
 use stackable_operator::Crd;
+
+pub const FINALIZER_NAME: &str = "zookeeper.stackable.tech/cleanup";
+pub const APP_NAME: &str = "zookeeper";
+pub const MANAGED_BY: &str = "stackable-zookeeper";
 
 // TODO: We need to validate the name of the cluster because it is used in pod and configmap names, it can't bee too long
 // This probably also means we shouldn't use the node_names in the pod_name...

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -8,7 +8,6 @@ use semver::{SemVerError, Version};
 use serde::{Deserialize, Serialize};
 use stackable_operator::Crd;
 
-pub const FINALIZER_NAME: &str = "zookeeper.stackable.tech/cleanup";
 pub const APP_NAME: &str = "zookeeper";
 pub const MANAGED_BY: &str = "stackable-zookeeper";
 

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -1,5 +1,5 @@
 mod error;
-mod util;
+pub mod util;
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::CustomResource;

--- a/crd/src/util.rs
+++ b/crd/src/util.rs
@@ -260,9 +260,9 @@ mod tests {
     #[case::trim_leading_and_trailing_slash("/test/", "test")]
     #[case::no_trim("test", "test")]
     #[case::unicode_characters("Spade: ♠", "Spade: ♠")]
-    #[case::unicode_characters("/Heart: ♥", "Heart: ♥")]
-    #[case::unicode_characters("Diamond: ♦/", "Diamond: ♦")]
-    #[case::unicode_characters("/Club: ♣/", "Club: ♣")]
+    #[case::unicode_characters_leading_slash("/Heart: ♥", "Heart: ♥")]
+    #[case::unicode_characters_trailing_slash("Diamond: ♦/", "Diamond: ♦")]
+    #[case::unicode_characters_both_slashes("/Club: ♣/", "Club: ♣")]
     fn valid_chroot(#[case] input: &str, #[case] expected_output: &str) {
         let output = check_chroot(Some(input))
             .expect("Valid chroots shouldn't return an error.")

--- a/crd/src/util.rs
+++ b/crd/src/util.rs
@@ -95,15 +95,15 @@ pub fn is_valid_chroot(chroot: Option<&str>) -> ZookeeperOperatorResult<Option<&
         });
     }
 
-    let _ = is_valid_node(chroot)?;
+    is_valid_node(chroot)?;
 
     Ok(Some(chroot))
 }
 
-/// Check if the name is a valid nome for a znode in Zookeeper
-/// This does not currently fail on presence of '/' which would in my opinion
-/// be a valid znode, but signify a nested structure
-// We may want to revisit this later depending on how exactly this code is used
+/// Check if the name is a valid nome for a znode in ZooHeeper
+/// This does not currently fail on presence of '/' as this would simply be a nested
+/// path (like a subdirectory in a folder structure)
+/// We may want to revisit this later depending on how exactly this code is used
 ///
 /// # Arguments
 ///

--- a/crd/src/util.rs
+++ b/crd/src/util.rs
@@ -28,7 +28,7 @@ pub enum TicketReferences {
 #[allow(dead_code)]
 pub struct ZookeeperConnectionInformation {
     // A connection string as defined by ZooKeeper
-    // https://zookeeper.apache.org/doc/r3.5.1-alpha/zookeeperProgrammers.html#ch_zkSessions
+    // https://zookeeper.apache.org/doc/current/zookeeperProgrammers.html#ch_zkSessions
     // This has the form `host:port[,host:port,...][/chroot]`
     // For example:
     //  - server1:2181,server2:2181
@@ -75,11 +75,11 @@ pub async fn get_zk_connection_info(
 ///
 /// # Arguments
 ///
-/// * `chroot` - The chroot string which should be checked against ZooKeepers naming rules
+/// * `chroot` - The chroot string which should be checked against ZooKeeper's naming rules
 ///
 /// # Errors
 ///
-/// * [`IllegalChroot`] if the name violates any of ZooKeepers naming rules
+/// * [`IllegalChroot`] if the name violates any of ZooKeeper's naming rules
 pub fn is_valid_chroot(chroot: Option<&str>) -> ZookeeperOperatorResult<Option<&str>> {
     let chroot = match chroot {
         None => return Ok(None),
@@ -100,7 +100,7 @@ pub fn is_valid_chroot(chroot: Option<&str>) -> ZookeeperOperatorResult<Option<&
     Ok(Some(chroot))
 }
 
-/// Check if the name is a valid nome for a znode in ZooHeeper
+/// Check if the name is a valid name for a znode in ZooKeeper
 /// This does not currently fail on presence of '/' as this would simply be a nested
 /// path (like a subdirectory in a folder structure)
 /// We may want to revisit this later depending on how exactly this code is used
@@ -135,7 +135,7 @@ pub fn is_valid_node(node_name: &str) -> ZookeeperOperatorResult<()> {
     }
 }
 
-// Checks the string for any illegal characters according to ZooKeepers rules and returns
+// Checks the string for any illegal characters according to ZooKeeper's rules and returns
 // a HashSet containing all illegal characters
 fn contains_illegal_character(node_name: &str) -> HashSet<char> {
     // The value E000 in the list below does not exactly match what is written in the Zookeeper

--- a/crd/src/util.rs
+++ b/crd/src/util.rs
@@ -1,0 +1,385 @@
+use crate::{ZooKeeperCluster, ZooKeeperClusterSpec, APP_NAME, MANAGED_BY};
+use k8s_openapi::api::core::v1::Pod;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+use kube::Api;
+use stackable_operator::client::Client;
+use stackable_operator::error::Error::{InvalidName, KubeError, MissingObjectKey};
+use stackable_operator::error::OperatorResult;
+use stackable_operator::labels::{
+    APP_INSTANCE_LABEL, APP_MANAGED_BY_LABEL, APP_NAME_LABEL, APP_ROLE_GROUP_LABEL,
+};
+use stackable_operator::pod_utils::is_pod_running_and_ready;
+use std::collections::BTreeMap;
+use tracing::{debug, warn};
+
+pub struct ZookeeperConnectionInformation {
+    pub connection_string: String,
+}
+
+pub async fn get_zk_connection_info(
+    client: &Client,
+    zookeeper_reference: ZooKeeperCluster,
+) -> OperatorResult<ZookeeperConnectionInformation> {
+    let zk_name = zookeeper_reference.metadata.name.unwrap();
+    let zk_namespace = zookeeper_reference.metadata.namespace.unwrap();
+
+    let zk_cluster = check_zookeeper_reference(client, &zk_name, &zk_namespace).await?;
+
+    let zk_pods = client
+        .list_with_label_selector(None, &get_match_labels(&zk_name))
+        .await?;
+
+    let connection_string = get_zk_connection_string_from_pods(zk_cluster.spec, zk_pods, None)?;
+
+    Ok(ZookeeperConnectionInformation { connection_string })
+}
+
+fn get_match_labels(name: &str) -> LabelSelector {
+    let mut zk_pod_matchlabels = BTreeMap::new();
+    // TODO: retrieve these from the zookeeper crd crate - which means moving them there first :)
+    zk_pod_matchlabels.insert(String::from(APP_NAME_LABEL), String::from(APP_NAME));
+    zk_pod_matchlabels.insert(String::from(APP_MANAGED_BY_LABEL), String::from(MANAGED_BY));
+
+    zk_pod_matchlabels.insert(String::from(APP_INSTANCE_LABEL), name.to_string());
+    zk_pod_matchlabels.insert(String::from(APP_NAME_LABEL), String::from("zookeeper"));
+
+    LabelSelector {
+        match_labels: Some(zk_pod_matchlabels),
+        ..Default::default()
+    }
+}
+
+//
+async fn check_zookeeper_reference(
+    client: &Client,
+    zk_name: &str,
+    zk_namespace: &str,
+) -> OperatorResult<ZooKeeperCluster> {
+    debug!(
+        "Checking ZookeeperReference if [{}] exists in namespace [{}].",
+        zk_name, zk_namespace
+    );
+    let api: Api<ZooKeeperCluster> = client.get_namespaced_api(zk_namespace);
+
+    let zk_cluster = api.get(zk_name).await;
+    // TODO: We need to watch the ZooKeeper resource and do _something_ when it goes down or when its nodes are changed
+
+    zk_cluster.map_err(|err| {
+        warn!(?err,
+                        "Referencing a ZooKeeper cluster that does not exist (or some other error while fetching it): [{}/{}], we will requeue and check again",
+                        zk_namespace,
+                        zk_name
+                    );
+                    KubeError {source: err}})
+}
+
+fn get_zk_connection_string_from_pods(
+    zookeeper_spec: ZooKeeperClusterSpec,
+    zk_pods: Vec<Pod>,
+    chroot: Option<&str>,
+) -> OperatorResult<String> {
+    let mut server_and_port_list = Vec::new();
+
+    for pod in zk_pods {
+        if !is_pod_running_and_ready(&pod) {
+            debug!(
+                "Pod [{:?}] is assigned to this cluster but not ready, aborting.. ",
+                pod.metadata.name
+            );
+            return Err(InvalidName {
+                errors: vec![String::from("pod not ready")],
+            });
+        }
+        let node_name = pod.spec.unwrap().node_name.unwrap();
+        let role_group = match pod
+            .metadata
+            .labels
+            .unwrap_or_default()
+            .get(APP_ROLE_GROUP_LABEL)
+        {
+            None => {
+                return Err(MissingObjectKey {
+                    key: APP_ROLE_GROUP_LABEL,
+                })
+            }
+            Some(role_group) => role_group.to_owned(),
+        };
+
+        server_and_port_list.push((node_name, get_zk_port(&zookeeper_spec, &role_group)?));
+    }
+
+    let conn_string = server_and_port_list
+        .iter()
+        .map(|(host, port)| format!("{}:{}", host, port))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    if let Some(chroot_content) = chroot {
+        Ok(format!("{}/{}", conn_string, chroot_content))
+    } else {
+        Ok(conn_string)
+    }
+}
+
+fn get_zk_port(_zk_cluster: &ZooKeeperClusterSpec, _role_group: &str) -> OperatorResult<u16> {
+    Ok(2181)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+    use rstest::rstest;
+
+    #[test]
+    fn get_labels_from_name() {
+        let test_name = "testcluster";
+        let selector = get_match_labels(test_name);
+
+        assert!(selector.match_expressions.is_none());
+
+        let generated_labels_selector = selector.match_labels.expect("labels were None");
+        assert!(generated_labels_selector.len() == 3);
+        assert_eq!(
+            generated_labels_selector
+                .get("app.kubernetes.io/name")
+                .unwrap(),
+            "zookeeper"
+        );
+        assert_eq!(
+            generated_labels_selector
+                .get("app.kubernetes.io/instance")
+                .unwrap(),
+            "testcluster"
+        );
+        assert_eq!(
+            generated_labels_selector
+                .get("app.kubernetes.io/managed-by")
+                .unwrap(),
+            "stackable-zookeeper"
+        );
+    }
+
+    #[rstest]
+    #[case(indoc! {"
+      version: 3.4.14
+      servers:
+        - node_name: debian
+    "},
+        indoc! {"
+        - apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test
+            labels:
+              app.kubernetes.io/name: zookeeper
+              app.kubernetes.io/role-group: default
+              app.kubernetes.io/instance: test
+          spec:
+            nodeName: debian
+            containers: []
+          status:
+            phase: Running
+            conditions:
+              - type: Ready
+                status: True
+        "},
+        None,
+        "debian:2181"
+)]
+    #[case(indoc! {"
+      version: 3.4.14
+      servers:
+        - node_name: worker-1.stackable.tech
+    "},
+    indoc! {"
+        - apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test
+            labels:
+              app.kubernetes.io/name: zookeeper
+              app.kubernetes.io/role-group: default
+              app.kubernetes.io/instance: test
+          spec:
+            nodeName: worker-1.stackable.tech
+            containers: []
+          status:
+            phase: Running
+            conditions:
+              - type: Ready
+                status: True
+        "},
+    Some("dev"),
+    "worker-1.stackable.tech:2181/dev"
+    )]
+    #[case(indoc! {"
+      version: 3.4.14
+      servers:
+        - node_name: debian
+    "},
+    indoc! {"
+        - apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test
+            labels:
+              app.kubernetes.io/name: zookeeper
+              app.kubernetes.io/role-group: default
+              app.kubernetes.io/instance: test
+          spec:
+            nodeName: worker-1.stackable.demo
+            containers: []
+          status:
+            phase: Running
+            conditions:
+              - type: Ready
+                status: True
+        - apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test
+            labels:
+              app.kubernetes.io/name: zookeeper
+              app.kubernetes.io/role-group: default
+              app.kubernetes.io/instance: test
+          spec:
+            nodeName: worker-2.stackable.demo
+            containers: []
+          status:
+            phase: Running
+            conditions:
+              - type: Ready
+                status: True
+        "},
+    Some("prod"),
+    "worker-1.stackable.demo:2181,worker-2.stackable.demo:2181/prod"
+    )]
+    fn get_connection_string(
+        #[case] zookeeper_spec: &str,
+        #[case] zk_pods: &str,
+        #[case] chroot: Option<&str>,
+        #[case] expected_result: &str,
+    ) {
+        let pods = parse_pod_list_from_yaml(zk_pods);
+        let zk = parse_zk_from_yaml(zookeeper_spec);
+
+        let conn_string =
+            get_zk_connection_string_from_pods(zk.clone(), pods.clone(), chroot.clone())
+                .expect("should not fail");
+        assert_eq!(expected_result, conn_string);
+    }
+
+    #[rstest]
+    #[case(indoc! {"
+      version: 3.4.14
+      servers:
+        - node_name: debian
+    "},
+    indoc! {"
+        - apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test
+            labels:
+              app.kubernetes.io/name: zookeeper
+              app.kubernetes.io/role-group: default
+              app.kubernetes.io/instance: test
+          spec:
+            nodeName: worker-1.stackable.demo
+            containers: []
+          status:
+            phase: Running
+            conditions:
+              - type: Ready
+                status: True
+        - apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test
+            labels:
+              app.kubernetes.io/name: zookeeper
+              app.kubernetes.io/role-group: default
+              app.kubernetes.io/instance: test
+          spec:
+            nodeName: worker-2.stackable.demo
+            containers: []
+          status:
+            phase: Pending
+            conditions:
+              - type: Ready
+                status: True
+        "},
+    Some("prod"),
+    )]
+    #[case(indoc! {"
+      version: 3.4.14
+      servers:
+        - node_name: debian
+    "},
+    indoc! {"
+        - apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test
+            labels:
+              app.kubernetes.io/name: zookeeper
+              app.kubernetes.io/role-group: default
+              app.kubernetes.io/instance: test
+          spec:
+            nodeName: worker-1.stackable.demo
+            containers: []
+          status:
+            phase: Running
+        "},
+    Some("prod"),
+    )]
+    #[case(indoc! {"
+      version: 3.4.14
+      servers:
+        - node_name: debian
+    "},
+    indoc! {"
+        - apiVersion: v1
+          kind: Pod
+          metadata:
+            name: test
+            labels:
+              app.kubernetes.io/role-group: default
+              app.kubernetes.io/instance: test
+          spec:
+            nodeName: worker-1.stackable.demo
+            containers: []
+          status:
+            phase: Running
+        "},
+    Some("prod"),
+    )]
+
+    fn get_connection_string_should_fail(
+        #[case] zookeeper_spec: &str,
+        #[case] zk_pods: &str,
+        #[case] chroot: Option<&str>,
+    ) {
+        let pods = parse_pod_list_from_yaml(zk_pods);
+        let zk = parse_zk_from_yaml(zookeeper_spec);
+
+        let conn_string =
+            get_zk_connection_string_from_pods(zk.clone(), pods.clone(), chroot.clone());
+
+        assert!(conn_string.is_err())
+    }
+
+    fn parse_pod_list_from_yaml(pod_config: &str) -> Vec<Pod> {
+        let kube_pods: Vec<k8s_openapi::api::core::v1::Pod> =
+            serde_yaml::from_str(pod_config).unwrap();
+        kube_pods
+            .iter()
+            .map(|pod| Pod::from(pod.to_owned()))
+            .collect()
+    }
+
+    fn parse_zk_from_yaml(zk_config: &str) -> ZooKeeperClusterSpec {
+        serde_yaml::from_str(zk_config).unwrap()
+    }
+}

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -29,12 +29,14 @@ use stackable_operator::reconcile::{
 use stackable_operator::{finalizer, metadata};
 use stackable_zookeeper_crd::{
     ZooKeeperCluster, ZooKeeperClusterSpec, ZooKeeperClusterStatus, ZooKeeperServer,
-    ZooKeeperVersion, APP_NAME, FINALIZER_NAME, MANAGED_BY,
+    ZooKeeperVersion, APP_NAME, MANAGED_BY,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
+
+const FINALIZER_NAME: &str = "zookeeper.stackable.tech/cleanup";
 
 const ID_LABEL: &str = "zookeeper.stackable.tech/id";
 

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -22,6 +22,7 @@ use stackable_operator::controller::{ControllerStrategy, ReconciliationState};
 use stackable_operator::error::OperatorResult;
 use stackable_operator::krustlet;
 use stackable_operator::labels;
+use stackable_operator::labels::APP_ROLE_GROUP_LABEL;
 use stackable_operator::pod_utils;
 use stackable_operator::reconcile::{
     ReconcileFunctionAction, ReconcileResult, ReconciliationContext,
@@ -749,6 +750,17 @@ impl ZooKeeperState {
             self.context.resource.spec.version.to_string(),
         );
         labels.insert(ID_LABEL.to_string(), id.to_string());
+
+        // This code is left here in preparation for the implementation of
+        // https://github.com/stackabletech/zookeeper-operator/issues/85
+        // until then we simply set a dummy value of "" to _simulate_ the presence
+        // of a role-group label, which is expected to be present by the implementation
+        // of [`stackable-zookeeper-crd::util::get_zk_connection_info`]
+        // TODO: Replace with actual role_group name once this operator supports them
+        labels.insert(
+            APP_ROLE_GROUP_LABEL.to_string(),
+            "unimplemented".to_ascii_lowercase(),
+        );
 
         labels
     }

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -29,17 +29,13 @@ use stackable_operator::reconcile::{
 use stackable_operator::{finalizer, metadata};
 use stackable_zookeeper_crd::{
     ZooKeeperCluster, ZooKeeperClusterSpec, ZooKeeperClusterStatus, ZooKeeperServer,
-    ZooKeeperVersion,
+    ZooKeeperVersion, APP_NAME, FINALIZER_NAME, MANAGED_BY,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
-const FINALIZER_NAME: &str = "zookeeper.stackable.tech/cleanup";
-
-const APP_NAME: &str = "zookeeper";
-const MANAGED_BY: &str = "stackable-zookeeper";
 const ID_LABEL: &str = "zookeeper.stackable.tech/id";
 
 type ZooKeeperReconcileResult = ReconcileResult<error::Error>;


### PR DESCRIPTION
Zookeeper acts as backing store for many other services. Operators for these services will have to retrieve connection information from a Zookeeper object.

This PR adds a first version of function to retrieve the connection string from the api-server.
Functionality was added to the CRD crate, as this is the one that is most commonly used by other operators already.