### PR TITLE
Added the usual derives for ZookeeperReference. Required to use that …

### DIFF
--- a/crd/src/util.rs
+++ b/crd/src/util.rs
@@ -7,6 +7,8 @@ use crate::util::TicketReferences::ErrZkPodWithoutName;
 use crate::{ZooKeeperCluster, ZooKeeperClusterSpec, APP_NAME, MANAGED_BY};
 use k8s_openapi::api::core::v1::Pod;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use stackable_operator::client::Client;
 use stackable_operator::error::OperatorResult;
 use stackable_operator::labels::{
@@ -30,6 +32,7 @@ pub enum TicketReferences {
 /// ZooKeeper ensemble to use in their CRDs.
 /// This has the benefit of keeping references to ZooKeeper ensembles consistent
 /// throughout the entire stack.
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
 pub struct ZookeeperReference {
     pub namespace: String,
     pub name: String,


### PR DESCRIPTION
…struct in a yaml configuration (see NiFi operator).