### PR TITLE
Update semver to 1.0.3 & remove kube-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -1353,6 +1353,12 @@ checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "semver-parser"
@@ -1544,10 +1550,9 @@ dependencies = [
  "indoc",
  "k8s-openapi",
  "kube",
- "kube-runtime",
  "rstest",
  "schemars",
- "semver",
+ "semver 1.0.3",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1567,7 +1572,6 @@ dependencies = [
  "handlebars",
  "k8s-openapi",
  "kube",
- "kube-runtime",
  "rstest",
  "serde",
  "serde_json",

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -10,10 +10,9 @@ version = "0.1.0-nightly"
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
 
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
-kube = { version = "0.52", default-features = false, features = ["jsonpatch", "derive"] }
-kube-runtime = "0.52"
+kube = { version = "0.52", default-features = false, features = ["derive", "jsonpatch"] }
 schemars = "0.8"
-semver = "0.11"
+semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -4,7 +4,7 @@ pub mod util;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, LabelSelector};
 use kube::CustomResource;
 use schemars::JsonSchema;
-use semver::{SemVerError, Version};
+use semver::{Error as SemVerError, Version};
 use serde::{Deserialize, Serialize};
 use stackable_operator::label_selector;
 use stackable_operator::Crd;

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -15,7 +15,6 @@ futures = "0.3"
 handlebars = "4.0"
 k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
 kube = { version = "0.52", default-features = false, features = ["jsonpatch"] }
-kube-runtime = "0.52"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = "0.21"


### PR DESCRIPTION
- kube-runtime as a dependency wasn't needed
- SemVer crate updated to 1.0.3 which required a minor code change