### PR TITLE
Adapt to operator pod name and create config map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,7 +1555,6 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "stackable-operator"
 version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#ed04ff725de4167ca70857431eded3209d9caf20"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1576,6 +1575,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "strum",
+ "strum_macros",
  "thiserror",
  "tokio",
  "tracing",

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -8,7 +8,8 @@ version = "0.1.0-nightly"
 
 [dependencies]
 product-config = { git = "https://github.com/stackabletech/product-config.git", branch = "main" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+#stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+stackable-operator = { path = "../../operator-rs" }
 
 k8s-openapi = { version = "0.12", default-features = false }
 kube = { version = "0.58", default-features = false, features = ["derive", "jsonpatch"] }

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -8,7 +8,8 @@ version = "0.1.0-nightly"
 
 [dependencies]
 product-config = { git = "https://github.com/stackabletech/product-config.git", branch = "main" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+#stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+stackable-operator = { path = "../../operator-rs" }
 stackable-zookeeper-crd = { path = "../crd" }
 
 async-trait = "0.1"

--- a/operator/src/error.rs
+++ b/operator/src/error.rs
@@ -21,9 +21,6 @@ pub enum Error {
         source: serde_json::Error,
     },
 
-    #[error("Invalid Configmap. No name found which is required to query the ConfigMap.")]
-    InvalidConfigMap,
-
     #[error("Pod contains invalid id: {source}")]
     InvalidId {
         #[from]

--- a/operator/src/error.rs
+++ b/operator/src/error.rs
@@ -3,6 +3,17 @@ use std::num::ParseIntError;
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error(
+        "ConfigMap of type [{cm_type}] is for pod with generate_name [{pod_name}] is missing."
+    )]
+    MissingConfigMapError {
+        cm_type: &'static str,
+        pod_name: String,
+    },
+
+    #[error("ConfigMap of type [{cm_type}] is missing the metadata.name. Maybe the config map was not created yet?")]
+    MissingConfigMapNameError { cm_type: &'static str },
+
     #[error("Kubernetes reported error: {source}")]
     KubeError {
         #[from]

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -666,7 +666,7 @@ impl ZookeeperState {
             // enhance with config map type label
             let mut cm_config_data_labels = recommended_labels.clone();
             cm_config_data_labels.insert(
-                configmap::CM_TYPE_LABEL.to_string(),
+                configmap::CONFIGMAP_TYPE_LABEL.to_string(),
                 CONFIG_MAP_TYPE_DATA.to_string(),
             );
 
@@ -709,7 +709,7 @@ impl ZookeeperState {
         // enhance with config map type label and the id for differentiation
         let mut cm_config_id_labels = recommended_labels.clone();
         cm_config_id_labels.insert(
-            configmap::CM_TYPE_LABEL.to_string(),
+            configmap::CONFIGMAP_TYPE_LABEL.to_string(),
             CONFIG_MAP_TYPE_ID.to_string(),
         );
         cm_config_id_labels.insert(ID_LABEL.to_string(), id.to_string());

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,7 +8,8 @@ version = "0.1.0-nightly"
 build = "build.rs"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+#stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+stackable-operator = { path = "../../operator-rs" }
 stackable-zookeeper-crd = { path = "../crd" }
 stackable-zookeeper-operator = { path = "../operator" }
 
@@ -19,7 +20,8 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+#stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+stackable-operator = { path = "../../operator-rs" }
 stackable-zookeeper-crd = { path = "../crd" }
 
 [package.metadata.deb]


### PR DESCRIPTION
## Description

- Split create_pod_and_config_maps into create_pod and create_config_maps
- Using operator-rs build_config_map and create_config_map
- Using operator-rs build_resource_name for pods and config maps.

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
