### PR TITLE
Adjust example ZookeeperCluster to adhere to CRD

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -20,7 +20,7 @@ To create a single node Apache ZooKeeper (v3.5.8) cluster with Prometheus metric
                     selector:
                         matchLabels:
                             kubernetes.io/arch: stackable-linux
-                replicas: 1
-                config:
-                    metricsPort: 9505
+                    replicas: 1
+                    config:
+                        metricsPort: 9505
     EOF


### PR DESCRIPTION
Adjusted based on inspecting https://github.com/stackabletech/zookeeper-operator/blob/main/deploy/crd/zookeepercluster.crd.yaml and that https://github.com/stackabletech/zookeeper-operator/blob/main/examples/simple-zookeepercluster.yaml works. 

Otherwise, get:
```
error: error validating "STDIN": error validating data: [ValidationError(ZookeeperCluster.spec.servers.roleGroups.config): unknown field "metricsPort" in tech.stackable.zookeeper.v1alpha1.ZookeeperCluster.spec.servers.roleGroups, ValidationError(ZookeeperCluster.spec.servers.roleGroups.config): missing required field "selector" in tech.stackable.zookeeper.v1alpha1.ZookeeperCluster.spec.servers.roleGroups, ValidationError(ZookeeperCluster.spec.servers.roleGroups.replicas): invalid type for tech.stackable.zookeeper.v1alpha1.ZookeeperCluster.spec.servers.roleGroups: got "integer", expected "map"]; if you choose to ignore these errors, turn validation off with --validate=false
```

## Description

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
