### PR TITLE
Mention that a JRE is required to run Zookeeper

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -36,6 +36,7 @@ After you added the repository run:
 [source,bash]
 ----
 sudo apt-get update
+sudo apt-get install openjdk-11-jre-headless
 sudo apt-get install stackable-zookeeper-operator
 ----
 


### PR DESCRIPTION
Or better, can https://github.com/stackabletech/zookeeper-operator/blob/main/server/Cargo.toml be adjusted so the deb/rpm packages have the JRE as a dependency? I wasn't sure how to do that.

## Description

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
