### PR TITLE
Change permissions check to only publish artifacts when a PR is created from the same repo, not from a fork

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -26,15 +26,10 @@ jobs:
         run: ~/.cargo/bin/cargo +nightly build --verbose --release
       - name: Build apt package
         run: ~/.cargo/bin/cargo deb --manifest-path server/Cargo.toml --no-build
-      - name: Check workflow permissions
-        id: check_permissions
-        uses: scherermichael-oss/action-has-permission@1.0.6
-        with:
-          required-permission: write
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish apt package
-        if: steps.check_permissions.outputs.has-permission
+        env:
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        if: env.NEXUS_PASSWORD != null
         run: >-
           /usr/bin/curl
           --fail
@@ -62,15 +57,10 @@ jobs:
         run: ~/.cargo/bin/cargo +nightly build --verbose --release
       - name: Build RPM package
         run: server/packaging/buildrpm.sh stackable-zookeeper-operator-server
-      - name: Check workflow permissions
-        id: check_permissions
-        uses: scherermichael-oss/action-has-permission@1.0.6
-        with:
-          required-permission: write
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish RPM package
-        if: steps.check_permissions.outputs.has-permission
+        env:
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        if: env.NEXUS_PASSWORD != null
         run: >-
           /usr/bin/curl
           --fail


### PR DESCRIPTION
## Description
We started using the action-has-permission action in our workflows a while ago in order to avoid unnecessary job failures, when dependabot created pull requests that don't have access to organization secrets, or someone creates a PR from a fork (which has the same issue).

However, this didn't seem to work for forks (as tested in #177) so I tried changing the way that we check for permissions to instead simply assign the secret to an env var and then check that in the relevant actions.

This PR is to ensure actions work as intended when created from the main repo.

I believe this behavior is triggered by the way in which the action checks permissions. If I don't misread the code, it checks whether the user (owner of the forked repo I assume?) has permissions on the main repo. Since my owner is actually an admin in that repo that check succeeds, but github still won't make secrets available to actions run from a fork so the actual repo push then fails.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
