### PR TITLE
Add workflow to push release artifacts to the proper repo

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -6,39 +6,16 @@ on:
       - main
   pull_request:
 
-env:
-  CARGO_TERM_COLOR: always
-  REPO_APT_DEV_URL: https://repo.stackable.tech/repository/deb-dev
-  REPO_RPM_DEV_URL: https://repo.stackable.tech/repository/rpm-dev
-
 jobs:
   debian10:
     runs-on: debian10
     steps:
       - uses: actions/checkout@v2
-      - name: Change version if is PR
-        if: ${{ github.event_name == 'pull_request' }}
-        # We use "mr" instead of "pr" to denote pull request builds, as this prefix comes before "nightly" when lexically
-        # sorting packages by version. This means that when installing the package without specifying a version the
-        # nighly version is considered more current than mr versions and installed by default
-        run: sed -i -e 's/^version = "\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/version = "\1-mr${{ github.event.number }}"/' server/Cargo.toml
-      - name: Build
-        run: ~/.cargo/bin/cargo +nightly build --verbose --release
-      - name: Build apt package
-        run: ~/.cargo/bin/cargo deb --manifest-path server/Cargo.toml --no-build
-      - name: Publish apt package
-        env:
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-        if: env.NEXUS_PASSWORD != null
-        run: >-
-          /usr/bin/curl
-          --fail
-          -u 'github:${{ secrets.NEXUS_PASSWORD }}'
-          -H "Content-Type: multipart/form-data"
-          --data-binary "@./$(find target/debian/ -name *.deb)"
-          "${{ env.REPO_APT_DEV_URL }}/"
-      - name: Clean
-        run: ~/.cargo/bin/cargo clean
+      - uses: stackabletech/actions/publish_debian@main
+        with:
+          target_repo: dev
+          binary_name: stackable-zookeeper-operator-server
+          cargo_path: server/Cargo.toml
 
   centos:
     runs-on: centos${{ matrix.node }}
@@ -47,25 +24,9 @@ jobs:
         node: [ 7, 8 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Change version if is PR
-        if: ${{ github.event_name == 'pull_request' }}
-        # We use "mr" instead of "pr" to denote pull request builds, as this prefix comes before "nightly" when lexically
-        # sorting packages by version. This means that when installing the package without specifying a version the
-        # nighly version is considered more current than mr versions and installed by default
-        run: sed -i -e 's/^version = "\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/version = "\1-mr${{ github.event.number }}"/' server/Cargo.toml
-      - name: Build
-        run: ~/.cargo/bin/cargo +nightly build --verbose --release
-      - name: Build RPM package
-        run: server/packaging/buildrpm.sh stackable-zookeeper-operator-server
-      - name: Publish RPM package
-        env:
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-        if: env.NEXUS_PASSWORD != null
-        run: >-
-          /usr/bin/curl
-          --fail
-          -u 'github:${{ secrets.NEXUS_PASSWORD }}'
-          --upload-file "./$(find  target/rpm/RPMS/x86_64/ -name *.rpm)"
-          "${{ env.REPO_RPM_DEV_URL }}/el${{ matrix.node }}/"
-      - name: Clean
-        run: ~/.cargo/bin/cargo clean
+      - uses: stackabletech/actions/publish_centos@main
+        with:
+          target_repo: dev
+          binary_name: stackable-zookeeper-operator-server
+          cargo_path: server/Cargo.toml
+          centos_version: ${{ matrix.node }}

--- a/.github/workflows/build_artifacts_release.yml
+++ b/.github/workflows/build_artifacts_release.yml
@@ -1,0 +1,58 @@
+name: Publish-Release-Artifacts
+
+on:
+  push:
+   tags:
+     - "*"
+
+env:
+  CARGO_TERM_COLOR: always
+  REPO_APT_DEV_URL: https://repo.stackable.tech/repository/deb-release
+  REPO_RPM_DEV_URL: https://repo.stackable.tech/repository/rpm-release
+
+jobs:
+  debian10:
+    runs-on: debian10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: ~/.cargo/bin/cargo +nightly build --verbose --release
+      - name: Build apt package
+        run: ~/.cargo/bin/cargo deb --manifest-path server/Cargo.toml --no-build
+      - name: Publish apt package
+        env:
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        if: env.NEXUS_PASSWORD != null
+        run: >-
+          /usr/bin/curl
+          --fail
+          -u 'github:${{ secrets.NEXUS_PASSWORD }}'
+          -H "Content-Type: multipart/form-data"
+          --data-binary "@./$(find target/debian/ -name *.deb)"
+          "${{ env.REPO_APT_DEV_URL }}/"
+      - name: Clean
+        run: ~/.cargo/bin/cargo clean
+
+  centos:
+    runs-on: centos${{ matrix.node }}
+    strategy:
+      matrix:
+        node: [ 7, 8 ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: ~/.cargo/bin/cargo +nightly build --verbose --release
+      - name: Build RPM package
+        run: server/packaging/buildrpm.sh stackable-zookeeper-operator-server
+      - name: Publish RPM package
+        env:
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        if: env.NEXUS_PASSWORD != null
+        run: >-
+          /usr/bin/curl
+          --fail
+          -u 'github:${{ secrets.NEXUS_PASSWORD }}'
+          --upload-file "./$(find  target/rpm/RPMS/x86_64/ -name *.rpm)"
+          "${{ env.REPO_RPM_DEV_URL }}/el${{ matrix.node }}/"
+      - name: Clean
+        run: ~/.cargo/bin/cargo clean

--- a/.github/workflows/build_artifacts_release.yml
+++ b/.github/workflows/build_artifacts_release.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  REPO_APT_DEV_URL: https://repo.stackable.tech/repository/deb-release
-  REPO_RPM_DEV_URL: https://repo.stackable.tech/repository/rpm-release
+  REPO_APT_RELEASE_URL: https://repo.stackable.tech/repository/deb-release
+  REPO_RPM_RELEASE_URL: https://repo.stackable.tech/repository/rpm-release
 
 jobs:
   debian10:
@@ -29,7 +29,7 @@ jobs:
           -u 'github:${{ secrets.NEXUS_PASSWORD }}'
           -H "Content-Type: multipart/form-data"
           --data-binary "@./$(find target/debian/ -name *.deb)"
-          "${{ env.REPO_APT_DEV_URL }}/"
+          "${{ env.REPO_APT_RELEASE_URL }}/"
       - name: Clean
         run: ~/.cargo/bin/cargo clean
 
@@ -53,6 +53,6 @@ jobs:
           --fail
           -u 'github:${{ secrets.NEXUS_PASSWORD }}'
           --upload-file "./$(find  target/rpm/RPMS/x86_64/ -name *.rpm)"
-          "${{ env.REPO_RPM_DEV_URL }}/el${{ matrix.node }}/"
+          "${{ env.REPO_RPM_RELEASE_URL }}/el${{ matrix.node }}/"
       - name: Clean
         run: ~/.cargo/bin/cargo clean


### PR DESCRIPTION
Add workflow to push release artifacts to the proper repo to the release repo (see https://github.com/stackabletech/issues/issues/86).

This is most definitely not in its final version and a very simplistic approach for now as I simply duplicated the entire artifacts code.

As per https://github.community/t/run-step-on-if-branch-tag-is/16965 there does not seem to be a simple way to add branching to the dev workflow when a tag triggers it.
Also, I think it might actually make sense to keep this separate to avoid any confusion on what is and what is not part of the release process. And if we need to add signing down the line or something like that this might also make it easier to keep things separate.

Currently this would build on all tags, we might want to discuss if we want to have rc beta tags separate or in general if there could be tags in our repos that are not releases..

fixes https://github.com/stackabletech/issues/issues/86 for zookeeper operator (comment mostly to link this to the issue in zh)

## Description

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
