### PR TITLE
`nodeport_hosts`: use provided `port_name` when trying to find `ServicePort`

### DIFF
--- a/rust/operator-binary/src/discovery.rs
+++ b/rust/operator-binary/src/discovery.rs
@@ -135,7 +135,7 @@ async fn nodeport_hosts(
                 .ports
                 .as_ref()?
                 .iter()
-                .find(|port| port.name.as_deref() == Some("zk"))
+                .find(|port| port.name.as_deref() == Some(port_name))
         })
         .context(NoServicePort { port_name })?;
     let node_port = svc_port.node_port.context(NoNodePort { port_name })?;


### PR DESCRIPTION
## Description

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
