### PR TITLE
Remove .git from dockerignore so built.rs can find the current hash when building the Docker image & binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,3 @@ target/
 
 .idea/
 *.iws
-.git


### PR DESCRIPTION
Found by @maltesander 

## Description

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
