### PR TITLE
Shut down gracefully on termination signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Shut down gracefully ([#338]).
+
+[#338]: https://github.com/stackabletech/zookeeper-operator/pull/338
+
 ## [0.8.0] - 2021-12-22
 
 

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -102,6 +102,7 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .owns(client.get_all_api::<StatefulSet>(), ListParams::default())
                 .owns(client.get_all_api::<ConfigMap>(), ListParams::default())
+                .shutdown_on_signal()
                 .run(
                     zk_controller::reconcile_zk,
                     zk_controller::error_policy,
@@ -131,6 +132,7 @@ async fn main() -> anyhow::Result<()> {
                             .map(|znode| ObjectRef::from_obj(&znode))
                     },
                 )
+                .shutdown_on_signal()
                 .run(
                     |znode, ctx| {
                         tokio01_runtime


### PR DESCRIPTION
## Description

This should make restarts *much* faster, and try to ensure that we don't shut
down in the middle of a reconciliation.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
