### PR TITLE
Chown data folder on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Shut down gracefully ([#338]).
+- Fixed ACL incompatibility with certain managed K8s providers ([#340]).
 
 [#338]: https://github.com/stackabletech/zookeeper-operator/pull/338
+[#340]: https://github.com/stackabletech/zookeeper-operator/pull/340
 
 ## [0.8.0] - 2021-12-22
 


### PR DESCRIPTION
## Description

This is required since some CSI providers only make the volume folder
accessible to root by default.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
