### PR TITLE
Bunched a couple of updates from dependabot to test them before merging them in the operator templating:

### DIFF
--- a/.github/workflows/pr_generate_manifests.yml
+++ b/.github/workflows/pr_generate_manifests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           token: ${{ secrets.STACKY_MC_STACKFACE_TOKEN }}
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v2.0
         with:
           version: v3.6.2
       - name: update manifests
@@ -28,7 +28,7 @@ jobs:
         env:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         if: env.NEXUS_PASSWORD != null
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v8.0.1
         with:
           default_author: user_info
           author_name: Stacky McStackface

--- a/.github/workflows/publish_main_artifacts.yml
+++ b/.github/workflows/publish_main_artifacts.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v2.0
         with:
           version: v3.6.2
 

--- a/.github/workflows/publish_pr_artifacts.yml
+++ b/.github/workflows/publish_pr_artifacts.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v2.0
         with:
           version: v3.6.2
 

--- a/.github/workflows/publish_release_artifacts.yml
+++ b/.github/workflows/publish_release_artifacts.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v2.0
         with:
           version: v3.6.2
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,6 +121,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
-      - uses: EmbarkStudios/cargo-deny-action@v1.2.6
+      - uses: EmbarkStudios/cargo-deny-action@v1.2.9
         with:
           command: check ${{ matrix.checks }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,6 +121,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
-      - uses: EmbarkStudios/cargo-deny-action@v1.2.9
+      - uses: EmbarkStudios/cargo-deny-action@v1.2.6
         with:
           command: check ${{ matrix.checks }}


### PR DESCRIPTION
## Description
This updates 3 github actions that are used in multiple repos. Since we had trouble with the deny action in the past this is used to test before rolling out the new versions via the templating to all operators.

- azure/setup-helm: v1 -> v2.0
- EndBug/add-and-commit: v7 -> v8.0.1



<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
