### PR TITLE
[Merged by Bors] - Default ZookeeperClusterRef's namespace to the ns of the Znode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- ZookeeperZnode.spec.clusterRef.namespace now defaults to .metadata.namespace ([#382]).
+
 ### Changed
 
 - Shut down gracefully ([#338]).
@@ -13,6 +17,7 @@ All notable changes to this project will be documented in this file.
 [#338]: https://github.com/stackabletech/zookeeper-operator/pull/338
 [#340]: https://github.com/stackabletech/zookeeper-operator/pull/340
 [#352]: https://github.com/stackabletech/zookeeper-operator/pull/352
+[#382]: https://github.com/stackabletech/zookeeper-operator/pull/382
 
 ## [0.8.0] - 2021-12-22
 

--- a/examples/simple-zookeeperznode.yaml
+++ b/examples/simple-zookeeperznode.yaml
@@ -5,4 +5,5 @@ metadata:
 spec:
   clusterRef:
     name: simple-zk
-    namespace: default
+    # Optional when ZookeeperZnode is in the same Namespace as the ZookeeperCluster
+    # namespace: default

--- a/rust/operator-binary/src/znode_controller.rs
+++ b/rust/operator-binary/src/znode_controller.rs
@@ -202,11 +202,16 @@ async fn find_zk_of_znode(
     client: &stackable_operator::client::Client,
     znode: &ZookeeperZnode,
 ) -> Result<ZookeeperCluster, Error> {
-    if let ZookeeperClusterRef {
-        name: Some(zk_name),
-        namespace: Some(zk_ns),
-    } = &znode.spec.cluster_ref
-    {
+    let ZookeeperClusterRef {
+        name: zk_name,
+        namespace: zk_ns,
+    } = &znode.spec.cluster_ref;
+    if let (Some(zk_name), Some(zk_ns)) = (
+        zk_name,
+        zk_ns
+            .as_deref()
+            .or_else(|| znode.metadata.namespace.as_deref()),
+    ) {
         client
             .get::<ZookeeperCluster>(zk_name, Some(zk_ns))
             .await


### PR DESCRIPTION
## Description

This ensures that references can now work without the manifest knowing which namespace it's being applied to.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
