### PR TITLE
Fix CHANGELOG claiming that we're still on operator-rs 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 - Shut down gracefully ([#338]).
 - Fixed ACL incompatibility with certain managed K8s providers ([#340]).
-- Operator-rs: 0.6.0 -> 0.8.0 ([#352]).
+- Operator-rs: 0.6.0 -> 0.10.0 ([#352], [#383]).
 - Cleanup for `ZookeeperZnode` now succeeds if the linked `ZookeeperCluster` was already deleted ([#384]).
 
 [#338]: https://github.com/stackabletech/zookeeper-operator/pull/338
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 [#352]: https://github.com/stackabletech/zookeeper-operator/pull/352
 [#380]: https://github.com/stackabletech/zookeeper-operator/pull/380
 [#382]: https://github.com/stackabletech/zookeeper-operator/pull/382
+[#383]: https://github.com/stackabletech/zookeeper-operator/pull/383
 [#384]: https://github.com/stackabletech/zookeeper-operator/pull/384
 [#406]: https://github.com/stackabletech/zookeeper-operator/pull/406
 


### PR DESCRIPTION
## Description

*Please add a description here. This will become the commit message of the merge request later.*

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
