### PR TITLE
[Merged by Bors] - Export discovery properties with split host list and chroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 - Enabled Prometheus scraping ([#380]).
 - ZookeeperZnode.spec.clusterRef.namespace now defaults to .metadata.namespace ([#382]).
 - PodSecurityContext.fsGroup to allow write access to mounted volumes ([#406]).
-- Added `ZOOKEEPER_HOSTS` and `ZOOKEEPER_CHROOT` to discovery config maps, for clients that do not support the composite connection string ([#421]).
+- Added `ZOOKEEPER_HOSTS` and `ZOOKEEPER_CHROOT` to discovery config maps,
+  for clients that do not support the composite connection string ([#421]).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - Enabled Prometheus scraping ([#380]).
 - ZookeeperZnode.spec.clusterRef.namespace now defaults to .metadata.namespace ([#382]).
-- PodSecurityContext.fsGroup to allow write access to mounted volumes ([406]).
+- PodSecurityContext.fsGroup to allow write access to mounted volumes ([#406]).
+- Added `ZOOKEEPER_HOSTS` and `ZOOKEEPER_CHROOT` to discovery config maps, for clients that do not support the composite connection string ([#421]).
 
 ### Changed
 
@@ -24,6 +25,7 @@ All notable changes to this project will be documented in this file.
 [#382]: https://github.com/stackabletech/zookeeper-operator/pull/382
 [#384]: https://github.com/stackabletech/zookeeper-operator/pull/384
 [#406]: https://github.com/stackabletech/zookeeper-operator/pull/406
+[#421]: https://github.com/stackabletech/zookeeper-operator/pull/421
 
 ## [0.8.0] - 2021-12-22
 


### PR DESCRIPTION


## Description

Required by NiFi, which inexplicably does its own connection string parsing

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
