### PR TITLE
Spike for Vector logging

### DIFF
--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -68,7 +68,7 @@ impl Configuration for ZookeeperConfig {
         _resource: &Self::Configurable,
         _role_name: &str,
     ) -> Result<BTreeMap<String, Option<String>>, ConfigError> {
-        let jvm_flags = "-javaagent:/stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar=9505:/stackable/jmx/server.yaml".to_string();
+        let jvm_flags = "-javaagent:/stackable/jmx/jmx_prometheus_javaagent-0.16.1.jar=9505:/stackable/jmx/server.yaml -Dlog4j.debug=true -Dlog4j.configuration=file:/stackable/config/log4j.properties".to_string();
         Ok([
             (
                 Self::MYID_OFFSET.to_string(),


### PR DESCRIPTION
## Description

This is a pretty dirty proof of concept for using [Vector](https://vector.dev) to parse and forward product logs into OpenSearch.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
