### PR TITLE
Migrate Jenkins CI tests to operator repo

### DIFF
--- a/.ci/integration-tests/hcloud-centos-8/cluster.yaml
+++ b/.ci/integration-tests/hcloud-centos-8/cluster.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: t2.stackable.tech/v1
+kind: Infra
+template: hcloud-centos-8
+metadata: 
+  name: zookeper-operator-integration-tests
+  description: "Cluster for Zookeeper Operator Integration Tests (Hetzner Cloud / CentOS 8)"
+domain: stackable.test
+publicKeys: []
+spec:
+  location: "hel1"
+  k8sVersion: "$K8S_VERSION"
+  wireguard: false
+  versions:
+    _-operator: NIGHTLY
+    zookeeper-operator: "$ZOOKEEPER_OPERATOR_VERSION"
+  nodes:
+    main:
+      numberOfNodes: 3

--- a/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,4 +1,4 @@
-git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git
+git clone -b $GIT_BRANCH https://github.com/stackabletech/zookeeper-operator.git
 (cd zookeeper-operator/ && ./scripts/run_tests.sh)
 exit_code=$?
 ./operator-logs.sh zookeeper > /target/zookeeper-operator.log

--- a/.ci/integration-tests/hcloud-centos-8/test.sh
+++ b/.ci/integration-tests/hcloud-centos-8/test.sh
@@ -1,0 +1,5 @@
+git clone -b $GIT_BRANCH https://github.com/stackabletech/integration-tests.git
+(cd zookeeper-operator/ && ./scripts/run_tests.sh)
+exit_code=$?
+./operator-logs.sh zookeeper > /target/zookeeper-operator.log
+exit $exit_code


### PR DESCRIPTION
## Description

Migrate Jenkins CI tests to operator repo

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

successfully ran: https://ci.stackable.tech/view/02%20Component%20Tests%20(flex)/job/Zookeeper%20Operator%20Integration%20Tests%20(flex)/52/

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
