### PR TITLE
[Merged by Bors] - Updated ZooKeeper image version to 0.7.1

### DIFF
--- a/docs/modules/ROOT/pages/config_properties.adoc
+++ b/docs/modules/ROOT/pages/config_properties.adoc
@@ -8,7 +8,7 @@ kind: ZookeeperCluster
 metadata:
   name: simple
 spec:
-  version: 3.8.0-stackable0.7.0
+  version: 3.8.0-stackable0.7.1
   servers:
     roleGroups:
       default:

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -19,7 +19,7 @@ kind: ZookeeperCluster
 metadata:
   name: simple-zk
 spec:
-  version: 3.8.0-stackable0.7.0
+  version: 3.8.0-stackable0.7.1
   servers:
     roleGroups:
       default:

--- a/examples/simple-zookeeper-cluster.yaml
+++ b/examples/simple-zookeeper-cluster.yaml
@@ -24,7 +24,7 @@ spec:
         replicas: 1
         config:
           myidOffset: 20
-  version: 3.8.0-stackable0.7.0
+  version: 3.8.0-stackable0.7.1
   stopped: false
 ---
 apiVersion: zookeeper.stackable.tech/v1alpha1

--- a/examples/simple-zookeeper-tls-cluster.yaml
+++ b/examples/simple-zookeeper-tls-cluster.yaml
@@ -4,7 +4,7 @@ kind: ZookeeperCluster
 metadata:
   name: simple-zk
 spec:
-  version: 3.8.0-stackable0.7.0
+  version: 3.8.0-stackable0.7.1
   config:
     tls:
       secretClass: tls

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -6,10 +6,10 @@ dimensions:
       - 3.6.3-stackable0.6.0
       - 3.7.0-stackable0.6.0
       - 3.8.0-stackable0.6.0
-      - 3.5.8-stackable0.7.0
-      - 3.6.3-stackable0.7.0
-      - 3.7.0-stackable0.7.0
-      - 3.8.0-stackable0.7.0
+      - 3.5.8-stackable0.7.1
+      - 3.6.3-stackable0.7.1
+      - 3.7.0-stackable0.7.1
+      - 3.8.0-stackable0.7.1
 tests:
   - name: smoke
     dimensions:


### PR DESCRIPTION
# Description

The new image version includes https://github.com/stackabletech/docker-images/pull/126 to fix some test flakiness due to cached dns responses.


<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
