### PR TITLE
[Merged by Bors] - test: Increase timeout for Zookeeper installation from 300 to 600

### DIFF
--- a/tests/templates/kuttl/smoke/00-assert.yaml
+++ b/tests/templates/kuttl/smoke/00-assert.yaml
@@ -3,7 +3,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 metadata:
   name: install-test-zk
-timeout: 300
+timeout: 600
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
# Description


<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
