### PR TITLE
[Merged by Bors] - Update name of operator clusterrole 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Operator-rs: 0.21.1 -> 0.22.0 ([#516]).
+- Include chart name when installing with a custom release name ([#517], [#518]).
 
 [#516]: https://github.com/stackabletech/zookeeper-operator/pull/516
+[#517]: https://github.com/stackabletech/zookeeper-operator/pull/517
+[#518]: https://github.com/stackabletech/zookeeper-operator/pull/518
 
 ## [0.10.0] - 2022-06-23
 

--- a/deploy/helm/zookeeper-operator/templates/roles.yaml
+++ b/deploy/helm/zookeeper-operator/templates/roles.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-clusterrole
+  name: {{ include "operator.fullname" . }}-clusterrole
 rules:
   - apiGroups:
       - ""


### PR DESCRIPTION
# Description

Leftover from https://github.com/stackabletech/zookeeper-operator/pull/517

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
