### PR TITLE
[Merged by Bors] - Fix bug where client TLS could not be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - Operator-rs: 0.21.1 -> 0.22.0 ([#516]).
 - Include chart name when installing with a custom release name ([#517], [#518]).
-- Fixed bug where client TLS could not be disabled ([#xxx]).
+- Fixed bug where client TLS could not be disabled ([#529]).
 
 [#516]: https://github.com/stackabletech/zookeeper-operator/pull/516
 [#517]: https://github.com/stackabletech/zookeeper-operator/pull/517
 [#518]: https://github.com/stackabletech/zookeeper-operator/pull/518
-[#xxx]: https://github.com/stackabletech/zookeeper-operator/pull/xxx
+[#529]: https://github.com/stackabletech/zookeeper-operator/pull/529
 
 ## [0.10.0] - 2022-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - Operator-rs: 0.21.1 -> 0.22.0 ([#516]).
 - Include chart name when installing with a custom release name ([#517], [#518]).
+- Fixed bug where client TLS could not be disabled ([#xxx]).
 
 [#516]: https://github.com/stackabletech/zookeeper-operator/pull/516
 [#517]: https://github.com/stackabletech/zookeeper-operator/pull/517
 [#518]: https://github.com/stackabletech/zookeeper-operator/pull/518
+[#xxx]: https://github.com/stackabletech/zookeeper-operator/pull/xxx
 
 ## [0.10.0] - 2022-06-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,7 @@ version = "0.11.0-nightly"
 dependencies = [
  "serde",
  "serde_json",
+ "serde_yaml",
  "snafu",
  "stackable-operator",
  "strum",

--- a/deploy/crd/zookeepercluster.crd.yaml
+++ b/deploy/crd/zookeepercluster.crd.yaml
@@ -24,6 +24,10 @@ spec:
               description: A cluster of ZooKeeper nodes
               properties:
                 config:
+                  default:
+                    tls:
+                      secretClass: tls
+                    quorumTlsSecretClass: tls
                   nullable: true
                   properties:
                     clientAuthentication:
@@ -36,9 +40,12 @@ spec:
                         - authenticationClass
                       type: object
                     quorumTlsSecretClass:
+                      default: tls
                       description: "Only affects quorum communication. Use mutual verification between Zookeeper Nodes (mandatory). This setting controls: - Which cert the servers should use to authenticate themselves against other servers - Which ca.crt to use when validating the other server"
                       type: string
                     tls:
+                      default:
+                        secretClass: tls
                       description: "Only affects client connections. This setting controls: - If TLS encryption is used at all - Which cert the servers should use to authenticate themselves against the client Defaults to `TlsSecretClass` { secret_class: \"tls\".to_string() }."
                       nullable: true
                       properties:

--- a/deploy/helm/zookeeper-operator/crds/crds.yaml
+++ b/deploy/helm/zookeeper-operator/crds/crds.yaml
@@ -26,6 +26,10 @@ spec:
               description: A cluster of ZooKeeper nodes
               properties:
                 config:
+                  default:
+                    tls:
+                      secretClass: tls
+                    quorumTlsSecretClass: tls
                   nullable: true
                   properties:
                     clientAuthentication:
@@ -38,9 +42,12 @@ spec:
                         - authenticationClass
                       type: object
                     quorumTlsSecretClass:
+                      default: tls
                       description: "Only affects quorum communication. Use mutual verification between Zookeeper Nodes (mandatory). This setting controls: - Which cert the servers should use to authenticate themselves against other servers - Which ca.crt to use when validating the other server"
                       type: string
                     tls:
+                      default:
+                        secretClass: tls
                       description: "Only affects client connections. This setting controls: - If TLS encryption is used at all - Which cert the servers should use to authenticate themselves against the client Defaults to `TlsSecretClass` { secret_class: \"tls\".to_string() }."
                       nullable: true
                       properties:

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -27,6 +27,10 @@ spec:
               description: A cluster of ZooKeeper nodes
               properties:
                 config:
+                  default:
+                    tls:
+                      secretClass: tls
+                    quorumTlsSecretClass: tls
                   nullable: true
                   properties:
                     clientAuthentication:
@@ -39,9 +43,12 @@ spec:
                         - authenticationClass
                       type: object
                     quorumTlsSecretClass:
+                      default: tls
                       description: "Only affects quorum communication. Use mutual verification between Zookeeper Nodes (mandatory). This setting controls: - Which cert the servers should use to authenticate themselves against other servers - Which ca.crt to use when validating the other server"
                       type: string
                     tls:
+                      default:
+                        secretClass: tls
                       description: "Only affects client connections. This setting controls: - If TLS encryption is used at all - Which cert the servers should use to authenticate themselves against the client Defaults to `TlsSecretClass` { secret_class: \"tls\".to_string() }."
                       nullable: true
                       properties:

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = "1.0.82"
 snafu = "0.7.1"
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.22.0" }
 strum = { version = "0.24.1", features = ["derive"] }
+
+[dev-dependencies]
+serde_yaml = "0.8"

--- a/rust/operator-binary/src/zk_controller.rs
+++ b/rust/operator-binary/src/zk_controller.rs
@@ -652,7 +652,7 @@ fn build_server_rolegroup_statefulset(
         })
         .service_account_name(SERVICE_ACCOUNT);
 
-    if zk.is_client_secure() {
+    if let Some(secret) = zk.client_tls_secret_class() {
         let secret_class = if let Some(auth_class) = client_authentication_class {
             match &auth_class.spec.provider {
                 AuthenticationClassProvider::Tls(tls) => tls.client_cert_secret_class.clone(),
@@ -672,7 +672,7 @@ fn build_server_rolegroup_statefulset(
             VolumeBuilder::new("client-tls")
                 .ephemeral(
                     SecretOperatorVolumeSourceBuilder::new(
-                        secret_class.unwrap_or_else(|| zk.client_tls_secret_class()),
+                        secret_class.unwrap_or_else(|| secret.secret_class.clone()),
                     )
                     .with_node_scope()
                     .with_pod_scope()

--- a/tests/templates/kuttl/smoke/00-install-zookeeper.yaml.j2
+++ b/tests/templates/kuttl/smoke/00-install-zookeeper.yaml.j2
@@ -5,10 +5,14 @@ metadata:
   name: test-zk
 spec:
   config:
+{% if test_scenario['values']['use-client-tls'] == 'true' %}
     tls:
       secretClass: tls
     clientAuthentication:
       authenticationClass: zk-client-tls
+{% else %}
+    tls: null
+{% endif %}
     quorumTlsSecretClass: tls
   servers:
     config:
@@ -36,6 +40,7 @@ spec:
                 capacity: '2Gi'
   version: {{ test_scenario['values']['zookeeper'] }}
   stopped: false
+{% if test_scenario['values']['use-client-tls'] == 'true' %}
 ---
 apiVersion: authentication.stackable.tech/v1alpha1
 kind: AuthenticationClass
@@ -58,6 +63,7 @@ spec:
           name: secret-provisioner-tls-zk-client-ca
           namespace: default
         autoGenerate: true
+{% endif %}
 ---
 apiVersion: zookeeper.stackable.tech/v1alpha1
 kind: ZookeeperZnode

--- a/tests/templates/kuttl/smoke/02-prepare-test-zookeeper.yaml
+++ b/tests/templates/kuttl/smoke/02-prepare-test-zookeeper.yaml
@@ -5,6 +5,6 @@ commands:
   - script: kubectl cp -n $NAMESPACE ./test_zookeeper.py  zk-test-helper-0:/tmp
   - script: kubectl cp -n $NAMESPACE ./requirements.txt zk-test-helper-0:/tmp
   - script: kubectl exec -n $NAMESPACE zk-test-helper-0 -- python -m venv /tmp/venv
-  - script: kubectl exec -n $NAMESPACE zk-test-helper-0 -- bash -c 'source /tmp/venv/bin/activate && pip install -r /tmp/requirements.txt'
+  - script: kubectl exec -n $NAMESPACE zk-test-helper-0 -- bash -c 'source /tmp/venv/bin/activate && pip install -q -r /tmp/requirements.txt'
   - script: kubectl cp -n $NAMESPACE ./test_tls.sh test-zk-server-primary-0:/tmp
   - script: kubectl cp -n $NAMESPACE ./test_heap.sh test-zk-server-primary-0:/tmp

--- a/tests/templates/kuttl/smoke/test_tls.sh.j2
+++ b/tests/templates/kuttl/smoke/test_tls.sh.j2
@@ -2,7 +2,12 @@
 # Usage: test_tls.sh namespace
 
 NAMESPACE=$1
+
+{% if test_scenario['values']['use-client-tls'] == 'true' %}
 SERVER="test-zk-server-primary-1.test-zk-server-primary.${NAMESPACE}.svc.cluster.local:2282"
+{% else %}
+SERVER="test-zk-server-primary-1.test-zk-server-primary.${NAMESPACE}.svc.cluster.local:2181"
+{% endif %}
 
 # just to be safe...
 unset QUORUM_STORE_SECRET
@@ -20,6 +25,7 @@ then
 fi
 echo "[SUCCESS] Unsecure client connection established!"
 
+{% if test_scenario['values']['use-client-tls'] == 'true' %}
 ############################################################################
 # We set the correct client tls credentials and expect to be able to connect
 ############################################################################
@@ -41,6 +47,7 @@ then
 fi
 echo "[SUCCESS] Secure and authenticated client connection established!"
 
+{% endif %}
 ############################################################################
 # We set the (wrong) quorum tls credentials and expect to fail (wrong certificate)
 ############################################################################

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -6,7 +6,12 @@ dimensions:
       - 3.6.3-stackable0.7.1
       - 3.7.0-stackable0.7.1
       - 3.8.0-stackable0.7.1
+  - name: use-client-tls
+    values:
+      - "true"
+      - "false"
 tests:
   - name: smoke
     dimensions:
       - zookeeper
+      - use-client-tls


### PR DESCRIPTION
# Description

- Client TLS can now be disabled by setting `spec.config.tls: null`
```
spec:
  version: 3.8.0-stackable0.7.1
  config:
    tls: null
    clientAuthentication:
      authenticationClass: zk-client-tls
    quorumTlsSecretClass: tls
```

fixes https://github.com/stackabletech/zookeeper-operator/issues/528

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
