### PR TITLE
[Merged by Bors] - Fixed error when creating the ZNode in a different namespace than the ZookeeperCluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Bugfix: java heap format ([#651])
+- Fixed operator error when creating the ZNode in a different namespace than the ZookeeperCluster ([#653])
 
 [#645]: https://github.com/stackabletech/zookeeper-operator/pull/645
 [#649]: https://github.com/stackabletech/zookeeper-operator/pull/649
 [#651]: https://github.com/stackabletech/zookeeper-operator/pull/651
+[#653]: https://github.com/stackabletech/zookeeper-operator/pull/653
 
 ## [23.1.0] - 2023-01-23
 


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/zookeeper-operator/issues/579

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
