### PR TITLE
[Merged by Bors] - Expose ZOOKEEPER_CLIENT_PORT in discovery CM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Generate OLM bundle for Release 23.4.0 ([#672]).
-- Expose `ZOOKEEPER_PORT` in discovery CM ([#675]).
+- Expose `ZOOKEEPER_CLIENT_PORT` in discovery CM ([#675], [#676]).
 
 ### Changed
 
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 [#673]: https://github.com/stackabletech/zookeeper-operator/pull/673
 [#674]: https://github.com/stackabletech/zookeeper-operator/pull/674
 [#675]: https://github.com/stackabletech/zookeeper-operator/pull/675
+[#676]: https://github.com/stackabletech/zookeeper-operator/pull/676
 
 ## [23.4.0] - 2023-04-17
 

--- a/rust/operator-binary/src/discovery.rs
+++ b/rust/operator-binary/src/discovery.rs
@@ -142,7 +142,7 @@ fn build_discovery_configmap(
         // Some clients don't support ZooKeeper's merged `hosts/chroot` format, so export them separately for these clients
         .add_data("ZOOKEEPER_HOSTS", hosts)
         .add_data(
-            "ZOOKEEPER_PORT",
+            "ZOOKEEPER_CLIENT_PORT",
             zookeeper_security.client_port().to_string(),
         )
         .add_data("ZOOKEEPER_CHROOT", chroot.unwrap_or("/"))


### PR DESCRIPTION
# Description

Fixup https://github.com/stackabletech/zookeeper-operator/pull/675

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
