### PR TITLE
[Merged by Bors] - Added kuttl test suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Expose `ZOOKEEPER_CLIENT_PORT` in discovery CM ([#675], [#676]).
 - Support for ZooKeeper `3.8.1` ([#689]).
 - Set explicit resources on all containers ([#693]).
+- Added kuttl test suites ([#696])
 
 ### Fixed
 
@@ -31,6 +32,7 @@ All notable changes to this project will be documented in this file.
 [#682]: https://github.com/stackabletech/zookeeper-operator/pull/682
 [#689]: https://github.com/stackabletech/zookeeper-operator/pull/689
 [#693]: https://github.com/stackabletech/zookeeper-operator/pull/693
+[#696]: https://github.com/stackabletech/zookeeper-operator/pull/696
 
 ## [23.4.0] - 2023-04-17
 

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -35,3 +35,18 @@ tests:
   - name: cluster-operation
     dimensions:
       - zookeeper-latest
+suites:
+  - name: latest
+    patch:
+      - dimensions:
+          - expr: last
+  - name: smoke
+    select:
+      - smoke
+  - name: openshift
+    patch:
+      - dimensions:
+          - expr: last
+      - dimensions:
+          - name: openshift
+            expr: "true"


### PR DESCRIPTION

# Description

Requires `beku 0.0.7`. Upgrade with:

```
pip install --upgrade beku-stackabletech
```

Added three test suites:

* `latest` : only run tests with the latest versions.
* `smoke` : only run smoke tests.
* `openshift` : only run latest versions with openshift=true.

To  run the `latest` test suite:

```
rm -rf tests/_work && beku -s latest
```

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Documentation added or updated
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
