### PR TITLE
[Merged by Bors] - nightly test suite

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -36,17 +36,31 @@ tests:
     dimensions:
       - zookeeper-latest
 suites:
-  - name: latest
+  - name: nightly
+    patch:
+      - dimensions:
+          - name: zookeeper
+            expr: last
+          - name: use-server-tls
+            expr: "true"
+          - name: use-client-auth-tls
+            expr: "true"
+  - name: smoke-latest
+    select:
+      - smoke
     patch:
       - dimensions:
           - expr: last
-  - name: smoke
-    select:
-      - smoke
   - name: openshift
     patch:
       - dimensions:
           - expr: last
       - dimensions:
+          - name: zookeeper
+            expr: last
+          - name: use-server-tls
+            expr: "true"
+          - name: use-client-auth-tls
+            expr: "true"
           - name: openshift
             expr: "true"


### PR DESCRIPTION
Part of https://github.com/stackabletech/ci/issues/62

```
(stackable) ➜  zookeeper-operator git:(feat/nightly-suite) ✗ beku -s nightly
INFO:root:Expanding test case id [smoke_zookeeper-3.8.1-stackable0.0.0-dev_use-server-tls-true_use-client-auth-tls-true]
INFO:root:Expanding test case id [delete-rolegroup_zookeeper-3.8.1-stackable0.0.0-dev]
INFO:root:Expanding test case id [znode_zookeeper-latest-3.8.1-stackable0.0.0-dev]
INFO:root:Expanding test case id [logging_zookeeper-3.8.1-stackable0.0.0-dev]
INFO:root:Expanding test case id [cluster-operation_zookeeper-latest-3.8.1-stackable0.0.0-dev]
```
```
(stackable) ➜  zookeeper-operator git:(feat/nightly-suite) ✗ beku -s smoke-latest
INFO:root:Expanding test case id [smoke_zookeeper-3.8.1-stackable0.0.0-dev_use-server-tls-false_use-client-auth-tls-false]
```
```
(stackable) ➜  zookeeper-operator git:(feat/nightly-suite) ✗ beku -s openshift   
INFO:root:Expanding test case id [smoke_zookeeper-3.8.1-stackable0.0.0-dev_use-server-tls-true_use-client-auth-tls-true]
INFO:root:Expanding test case id [delete-rolegroup_zookeeper-3.8.1-stackable0.0.0-dev]
INFO:root:Expanding test case id [znode_zookeeper-latest-3.8.1-stackable0.0.0-dev]
INFO:root:Expanding test case id [logging_zookeeper-3.8.1-stackable0.0.0-dev]
INFO:root:Expanding test case id [cluster-operation_zookeeper-latest-3.8.1-stackable0.0.0-dev]
```
