### PR TITLE
JVM config overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Default stackableVersion to operator version ([#711]).
-- Configuration overrides for the JVM security properties ([#715]).
+- Configuration overrides for the JVM security properties, such as DNS caching ([#715]).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Default stackableVersion to operator version ([#711]).
-- Configuration overrides for the JVM security properties (#715).
+- Configuration overrides for the JVM security properties ([#715]).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Default stackableVersion to operator version ([#711]).
+- Configuration overrides for the JVM security properties (#715).
 
 ### Changed
 
@@ -17,6 +18,7 @@ All notable changes to this project will be documented in this file.
 [#695]: https://github.com/stackabletech/zookeeper-operator/pull/695
 [#709]: https://github.com/stackabletech/zookeeper-operator/pull/709
 [#711]: https://github.com/stackabletech/zookeeper-operator/pull/711
+[#715]: https://github.com/stackabletech/zookeeper-operator/pull/715
 
 ## [23.7.0] - 2023-07-14
 

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -22,7 +22,7 @@ properties:
         min: "0"
       recommendedValues:
         - fromVersion: "0.0.0"
-          value: "0"
+          value: "5"
       roles:
         - name: "server"
           required: true

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -11,6 +11,44 @@ spec:
         regex: "^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"
 
 properties:
+  - property: &jvmDnsCacheTtl
+      propertyNames:
+        - name: "networkaddress.cache.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "0"
+      roles:
+        - name: "server"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for successfully resolved domain names."
+      description: "TTL for successfully resolved domain names."
+
+  - property: &jvmDnsCacheNegativeTtl
+      propertyNames:
+        - name: "networkaddress.cache.negative.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "0"
+      roles:
+        - name: "server"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for domain names that cannot be resolved."
+      description: "TTL for domain names that cannot be resolved."
+
   - property: &tickTime
       propertyNames:
         - name: "tickTime"

--- a/deploy/helm/zookeeper-operator/configs/properties.yaml
+++ b/deploy/helm/zookeeper-operator/configs/properties.yaml
@@ -22,7 +22,7 @@ properties:
         min: "0"
       recommendedValues:
         - fromVersion: "0.0.0"
-          value: "0"
+          value: "5"
       roles:
         - name: "server"
           required: true

--- a/deploy/helm/zookeeper-operator/configs/properties.yaml
+++ b/deploy/helm/zookeeper-operator/configs/properties.yaml
@@ -11,6 +11,44 @@ spec:
         regex: "^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"
 
 properties:
+  - property: &jvmDnsCacheTtl
+      propertyNames:
+        - name: "networkaddress.cache.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "0"
+      roles:
+        - name: "server"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for successfully resolved domain names."
+      description: "TTL for successfully resolved domain names."
+
+  - property: &jvmDnsCacheNegativeTtl
+      propertyNames:
+        - name: "networkaddress.cache.negative.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "0"
+      roles:
+        - name: "server"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for domain names that cannot be resolved."
+      description: "TTL for domain names that cannot be resolved."
+
   - property: &tickTime
       propertyNames:
         - name: "tickTime"

--- a/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
@@ -56,7 +56,7 @@ The JVM manages it's own cache of successfully resolved host names as well as a 
         networkaddress.cache.negative.ttl: "0"
 ----
 
-NOTE: The operator already disables negative DNS caching by default for Zookeeper.
+NOTE: The operator configures DNS caching by default as shown in the example above.
 
 For details on the JVM security see https://docs.oracle.com/en/java/javase/11/security/java-security-overview1.html
 

--- a/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
@@ -45,7 +45,7 @@ For a full list of configuration options we refer to the Apache ZooKeeper https:
 
 The `security.properties` file is used to configure JVM security properties. It is very seldom that users need to tweak any of these, but there is one use-case that stands out and that users need to be aware of: the JVM DNS cache.
 
-The JVM manages it's own cache of successfully resolved host names as well as a cache of host names that cannot be resolved. Some products of the Stackable stack are very sensible to the contents of these caches and their performance is heavily affected by them. Apache Zookeeper always requires up-to-date IP adreses to maintain it's quorum. To gurantee this, the JVM caches need to be effectively disabled. This can be achieved by setting the TTL of the cache entries to zero, like this:
+The JVM manages it's own cache of successfully resolved host names as well as a cache of host names that cannot be resolved. Some products of the Stackable stack are very sensible to the contents of these caches and their performance is heavily affected by them. Apache Zookeeper always requires up-to-date IP adreses to maintain it's quorum. To guarantee this, the JVM caches need to be effectively disabled. This can be achieved by setting the TTL of the cache entries to zero, like this:
 
 [source,yaml]
 ----
@@ -59,7 +59,7 @@ servers:
       replicas: 1
 ----
 
-NOTE: The operator already disables DNS caching by default for Zookeeper, so users don't need to do it explicitely.
+NOTE: The operator already disables DNS caching by default for Zookeeper, so users don't need to do it explicitly.
 
 For details on the JVM security see https://docs.oracle.com/en/java/javase/11/security/java-security-overview1.html
 

--- a/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
@@ -45,7 +45,7 @@ For a full list of configuration options we refer to the Apache ZooKeeper https:
 
 The `security.properties` file is used to configure JVM security properties. It is very seldom that users need to tweak any of these, but there is one use-case that stands out and that users need to be aware of: the JVM DNS cache.
 
-The JVM manages it's own cache of successfully resolved host names as well as a cache of host names that cannot be resolved. Some products of the Stackable stack are very sensible to the contents of these caches and their performance is heavily affected by them. Apache Zookeeper always requires up-to-date IP adreses to maintain it's quorum. To guarantee this, the JVM caches need to be effectively disabled. This can be achieved by setting the TTL of the cache entries to zero, like this:
+The JVM manages it's own cache of successfully resolved host names as well as a cache of host names that cannot be resolved. Some products of the Stackable platform are very sensible to the contents of these caches and their performance is heavily affected by them. Apache Zookeeper always requires up-to-date IP adreses to maintain it's quorum. To guarantee this, the JVM caches need to be effectively disabled. This can be achieved by setting the TTL of the cache entries to zero, like this:
 
 [source,yaml]
 ----
@@ -59,7 +59,7 @@ servers:
       replicas: 1
 ----
 
-NOTE: The operator already disables DNS caching by default for Zookeeper, so users don't need to do it explicitly.
+NOTE: The operator already disables DNS caching by default for Zookeeper.
 
 For details on the JVM security see https://docs.oracle.com/en/java/javase/11/security/java-security-overview1.html
 

--- a/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
@@ -45,7 +45,7 @@ For a full list of configuration options we refer to the Apache ZooKeeper https:
 
 The `security.properties` file is used to configure JVM security properties. It is very seldom that users need to tweak any of these, but there is one use-case that stands out, and that users need to be aware of: the JVM DNS cache.
 
-The JVM manages it's own cache of successfully resolved host names as well as a cache of host names that cannot be resolved. Some products of the Stackable platform are very sensible to the contents of these caches and their performance is heavily affected by them. As of version 3.5.8, Apache Zookeeper always requires up-to-date IP adreses to maintain it's quorum. To guarantee this, the negative DNS cache of the JVM needs to be disabled. This can be achieved by setting the TTL of entries in the negative cache to zero, like this:
+The JVM manages it's own cache of successfully resolved host names as well as a cache of host names that cannot be resolved. Some products of the Stackable platform are very sensible to the contents of these caches and their performance is heavily affected by them. As of version 3.8.1, Apache Zookeeper always requires up-to-date IP adreses to maintain it's quorum. To guarantee this, the negative DNS cache of the JVM needs to be disabled. This can be achieved by setting the TTL of entries in the negative cache to zero, like this:
 
 [source,yaml]
 ----

--- a/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
@@ -45,18 +45,18 @@ For a full list of configuration options we refer to the Apache ZooKeeper https:
 
 The `security.properties` file is used to configure JVM security properties. It is very seldom that users need to tweak any of these, but there is one use-case that stands out and that users need to be aware of: the JVM DNS cache.
 
-The JVM manages it's own cache of successfully resolved host names as well as a cache of host names that cannot be resolved. Some products of the Stackable platform are very sensible to the contents of these caches and their performance is heavily affected by them. Apache Zookeeper always requires up-to-date IP adreses to maintain it's quorum. To guarantee this, the JVM caches need to be effectively disabled. This can be achieved by setting the TTL of the cache entries to zero, like this:
+The JVM manages it's own cache of successfully resolved host names as well as a cache of host names that cannot be resolved. Some products of the Stackable platform are very sensible to the contents of these caches and their performance is heavily affected by them. As of version 3.5.8, Apache Zookeeper always requires up-to-date IP adreses to maintain it's quorum. To guarantee this, the negative DNS cache of the JVM needs to be disabled. This can be achieved by setting the TTL of entries in the negative cache to zero, like this:
 
 [source,yaml]
 ----
   servers:
     configOverrides:
       security.properties:
-        networkaddress.cache.ttl: "0"
+        networkaddress.cache.ttl: "5"
         networkaddress.cache.negative.ttl: "0"
 ----
 
-NOTE: The operator already disables DNS caching by default for Zookeeper.
+NOTE: The operator already disables negative DNS caching by default for Zookeeper.
 
 For details on the JVM security see https://docs.oracle.com/en/java/javase/11/security/java-security-overview1.html
 

--- a/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
@@ -7,7 +7,11 @@ IMPORTANT: Overriding certain properties which are set by operator (such as the 
 
 == Configuration properties
 
-For a role or role group, at the same level of `config`, you can specify: `configOverrides` for the `zoo.cfg`. For example, if you want to set the `4lw.commands.whitelist` to allow the `ruok` administrative command, it can be configured in the `ZookeeperCluster` resource like so:
+For a role or role group, at the same level of `config`, you can specify: `configOverrides` for the `zoo.cfg` and `security.properties` files.
+
+=== Overriding entries in zoo.cfg
+
+For example, if you want to set the `4lw.commands.whitelist` to allow the `ruok` administrative command, it can be configured in the `ZookeeperCluster` resource like so:
 
 [source,yaml]
 ----
@@ -24,7 +28,7 @@ Just as for the `config`, it is possible to specify this at role level as well:
 
 [source,yaml]
 ----
-routers:
+servers:
   configOverrides:
     zoo.cfg:
       4lw.commands.whitelist: "srvr, ruok"
@@ -33,9 +37,31 @@ routers:
       replicas: 1
 ----
 
-All override property values must be strings.
+All property values must be strings.
 
 For a full list of configuration options we refer to the Apache ZooKeeper https://zookeeper.apache.org/doc/r3.7.0/zookeeperAdmin.html#sc_configuration[Configuration Reference].
+
+=== Overriding entries in security.properties
+
+The `security.properties` file is used to configure JVM security properties. It is very seldom that users need to tweak any of these, but there is one use-case that stands out and that users need to be aware of: the JVM DNS cache.
+
+The JVM manages it's own cache of successfully resolved host names as well as a cache of host names that cannot be resolved. Some products of the Stackable stack are very sensible to the contents of these caches and their performance is heavily affected by them. Apache Zookeeper always requires up-to-date IP adreses to maintain it's quorum. To gurantee this, the JVM caches need to be effectively disabled. This can be achieved by setting the TTL of the cache entries to zero, like this:
+
+[source,yaml]
+----
+servers:
+  configOverrides:
+    security.properties
+      networkaddress.cache.ttl: '0'
+      networkaddress.cache.negative.ttl: '0'
+  roleGroups:
+    default:
+      replicas: 1
+----
+
+NOTE: The operator already disables DNS caching by default for Zookeeper, so users don't need to do it explicitely.
+
+For details on the JVM security see https://docs.oracle.com/en/java/javase/11/security/java-security-overview1.html
 
 == Environment variables
 

--- a/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
@@ -43,7 +43,7 @@ For a full list of configuration options we refer to the Apache ZooKeeper https:
 
 === Overriding entries in security.properties
 
-The `security.properties` file is used to configure JVM security properties. It is very seldom that users need to tweak any of these, but there is one use-case that stands out and that users need to be aware of: the JVM DNS cache.
+The `security.properties` file is used to configure JVM security properties. It is very seldom that users need to tweak any of these, but there is one use-case that stands out, and that users need to be aware of: the JVM DNS cache.
 
 The JVM manages it's own cache of successfully resolved host names as well as a cache of host names that cannot be resolved. Some products of the Stackable platform are very sensible to the contents of these caches and their performance is heavily affected by them. As of version 3.5.8, Apache Zookeeper always requires up-to-date IP adreses to maintain it's quorum. To guarantee this, the negative DNS cache of the JVM needs to be disabled. This can be achieved by setting the TTL of entries in the negative cache to zero, like this:
 

--- a/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
@@ -49,14 +49,11 @@ The JVM manages it's own cache of successfully resolved host names as well as a 
 
 [source,yaml]
 ----
-servers:
-  configOverrides:
-    security.properties
-      networkaddress.cache.ttl: '0'
-      networkaddress.cache.negative.ttl: '0'
-  roleGroups:
-    default:
-      replicas: 1
+  servers:
+    configOverrides:
+      security.properties:
+        networkaddress.cache.ttl: "0"
+        networkaddress.cache.negative.ttl: "0"
 ----
 
 NOTE: The operator already disables DNS caching by default for Zookeeper.

--- a/rust/operator-binary/src/zk_controller.rs
+++ b/rust/operator-binary/src/zk_controller.rs
@@ -876,28 +876,3 @@ pub fn error_policy(
 ) -> controller::Action {
     controller::Action::requeue(Duration::from_secs(5))
 }
-
-#[cfg(test)]
-mod tests {
-
-    #[test]
-    fn test_jvm_config_overrides() {
-        let input = r#"
-        apiVersion: zookeeper.stackable.tech/v1alpha1
-        kind: ZookeeperCluster
-        metadata:
-          name: simple
-        spec:
-          image:
-            productVersion: 3.8.1
-          servers:
-            roleGroups:
-              default:
-                configOverrides:
-                  security.properties:
-                    neworkaddress.cache.ttl: '1'
-                    neworkaddress.cache.negative.ttl: '2'
-        "#;
-        //        let zookeeper: ZookeeperCluster = serde_yaml::from_str(input).expect("illegal test input");
-    }
-}

--- a/rust/operator-binary/src/zk_controller.rs
+++ b/rust/operator-binary/src/zk_controller.rs
@@ -53,9 +53,10 @@ use stackable_operator::{
 };
 use stackable_zookeeper_crd::{
     security::ZookeeperSecurity, Container, ZookeeperCluster, ZookeeperClusterStatus,
-    ZookeeperConfig, ZookeeperRole, DOCKER_IMAGE_BASE_NAME, MAX_PREPARE_LOG_FILE_SIZE,
-    MAX_ZK_LOG_FILES_SIZE, STACKABLE_CONFIG_DIR, STACKABLE_DATA_DIR, STACKABLE_LOG_CONFIG_DIR,
-    STACKABLE_LOG_DIR, STACKABLE_RW_CONFIG_DIR, ZOOKEEPER_PROPERTIES_FILE,
+    ZookeeperConfig, ZookeeperRole, DOCKER_IMAGE_BASE_NAME, JVM_SECURITY_PROPERTIES_FILE,
+    MAX_PREPARE_LOG_FILE_SIZE, MAX_ZK_LOG_FILES_SIZE, STACKABLE_CONFIG_DIR, STACKABLE_DATA_DIR,
+    STACKABLE_LOG_CONFIG_DIR, STACKABLE_LOG_DIR, STACKABLE_RW_CONFIG_DIR,
+    ZOOKEEPER_PROPERTIES_FILE,
 };
 use std::{
     borrow::Cow,
@@ -255,6 +256,7 @@ pub async fn reconcile_zk(zk: Arc<ZookeeperCluster>, ctx: Arc<Ctx>) -> Result<co
                     vec![
                         PropertyNameKind::Env,
                         PropertyNameKind::File(ZOOKEEPER_PROPERTIES_FILE.to_string()),
+                        PropertyNameKind::File(JVM_SECURITY_PROPERTIES_FILE.to_string()),
                     ],
                     zk.spec.servers.clone().context(NoServerRoleSnafu)?,
                 ),
@@ -478,7 +480,15 @@ fn build_server_rolegroup_config_map(
         )
     }));
 
-    zoo_cfg.extend(zookeeper_security.config_settings());
+    let jvm_sec_props: BTreeMap<String, Option<String>> = server_config
+        .get(&PropertyNameKind::File(
+            JVM_SECURITY_PROPERTIES_FILE.to_string(),
+        ))
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(k, v)| (k, Some(v)))
+        .collect();
 
     let role =
         ZookeeperRole::from_str(&rolegroup.role).with_context(|_| RoleParseFailureSnafu {
@@ -505,6 +515,14 @@ fn build_server_rolegroup_config_map(
                     &rolegroup.role_group,
                 ))
                 .build(),
+        )
+        .add_data(
+            JVM_SECURITY_PROPERTIES_FILE,
+            to_java_properties_string(jvm_sec_props.iter()).with_context(|_| {
+                SerializeZooCfgSnafu {
+                    rolegroup: rolegroup.clone(),
+                }
+            })?,
         )
         .add_data(
             ZOOKEEPER_PROPERTIES_FILE,
@@ -857,4 +875,29 @@ pub fn error_policy(
     _ctx: Arc<Ctx>,
 ) -> controller::Action {
     controller::Action::requeue(Duration::from_secs(5))
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_jvm_config_overrides() {
+        let input = r#"
+        apiVersion: zookeeper.stackable.tech/v1alpha1
+        kind: ZookeeperCluster
+        metadata:
+          name: simple
+        spec:
+          image:
+            productVersion: 3.8.1
+          servers:
+            roleGroups:
+              default:
+                configOverrides:
+                  security.properties:
+                    neworkaddress.cache.ttl: '1'
+                    neworkaddress.cache.negative.ttl: '2'
+        "#;
+        //        let zookeeper: ZookeeperCluster = serde_yaml::from_str(input).expect("illegal test input");
+    }
 }

--- a/rust/operator-binary/src/zk_controller.rs
+++ b/rust/operator-binary/src/zk_controller.rs
@@ -480,6 +480,8 @@ fn build_server_rolegroup_config_map(
         )
     }));
 
+    zoo_cfg.extend(zookeeper_security.config_settings());
+
     let jvm_sec_props: BTreeMap<String, Option<String>> = server_config
         .get(&PropertyNameKind::File(
             JVM_SECURITY_PROPERTIES_FILE.to_string(),


### PR DESCRIPTION
Make JVM security settings related to the DNS cache configurable with configOverrides.

Tested manually that when caching negative results for 5 minutes, the quorum is not reached.

CI: https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/zookeeper-operator-it-custom/63/

# Description

*Please add a description here. This will become the commit message of the merge request later.*


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
