### PR TITLE
docs: Add listener-operator where missing

### DIFF
--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
@@ -27,6 +27,7 @@ echo "Installing Operators with Helm"
 # tag::helm-install-operators[]
 helm install --wait commons-operator stackable-dev/commons-operator --version 0.0.0-dev
 helm install --wait secret-operator stackable-dev/secret-operator --version 0.0.0-dev
+helm install --wait listener-operator stackable-dev/listener-operator --version 0.0.0-dev
 helm install --wait zookeeper-operator stackable-dev/zookeeper-operator --version 0.0.0-dev
 # end::helm-install-operators[]
 ;;
@@ -36,6 +37,7 @@ echo "installing Operators with stackablectl"
 stackablectl operator install \
   commons=0.0.0-dev \
   secret=0.0.0-dev \
+  listener=0.0.0-dev \
   zookeeper=0.0.0-dev
 # end::stackablectl-install-operators[]
 ;;

--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
@@ -27,6 +27,7 @@ echo "Installing Operators with Helm"
 # tag::helm-install-operators[]
 helm install --wait commons-operator {{ helm.repo_name }}/commons-operator --version {{ versions.commons }}
 helm install --wait secret-operator {{ helm.repo_name }}/secret-operator --version {{ versions.secret }}
+helm install --wait listener-operator {{ helm.repo_name }}/listener-operator --version {{ versions.listener }}
 helm install --wait zookeeper-operator {{ helm.repo_name }}/zookeeper-operator --version {{ versions.zookeeper }}
 # end::helm-install-operators[]
 ;;
@@ -36,6 +37,7 @@ echo "installing Operators with stackablectl"
 stackablectl operator install \
   commons={{ versions.commons }} \
   secret={{ versions.secret }} \
+  listener={{ versions.listener }} \
   zookeeper={{ versions.zookeeper }}
 # end::stackablectl-install-operators[]
 ;;

--- a/docs/modules/zookeeper/examples/getting_started/code/install_output.txt
+++ b/docs/modules/zookeeper/examples/getting_started/code/install_output.txt
@@ -1,3 +1,4 @@
 [INFO ] Installing commons operator in version 0.0.0-dev
 [INFO ] Installing secret operator in version 0.0.0-dev
+[INFO ] Installing listener operator in version 0.0.0-dev
 [INFO ] Installing zookeeper operator in version 0.0.0-dev

--- a/docs/modules/zookeeper/examples/getting_started/code/install_output.txt.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/install_output.txt.j2
@@ -1,3 +1,4 @@
 [INFO ] Installing commons operator in version {{ versions.commons }}
 [INFO ] Installing secret operator in version {{ versions.secret }}
+[INFO ] Installing listener operator in version {{ versions.listener }}
 [INFO ] Installing zookeeper operator in version {{ versions.zookeeper }}

--- a/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
@@ -4,6 +4,8 @@ kind: ZookeeperCluster
 metadata:
   name: simple-zk
 spec:
+  clusterConfig:
+    listenerClass: external-unstable
   image:
     productVersion: 3.8.3
   servers:

--- a/docs/modules/zookeeper/pages/index.adoc
+++ b/docs/modules/zookeeper/pages/index.adoc
@@ -33,7 +33,7 @@ ConfigMap give access information for the ZNode. xref:zookeeper:znodes.adoc[lear
 
 == Dependencies
 
-Apache ZooKeeper and the Stackable Operator have no dependencies besides the xref:commons-operator:index.adoc[] and xref:secret-operator:index.adoc[].
+Apache ZooKeeper and the Stackable Operator have no dependencies besides the xref:commons-operator:index.adoc[], xref:secret-operator:index.adoc[] and xref:listener-operator:index.adoc[].
 
 == [[demos]]Demos
 

--- a/docs/templating_vars.yaml
+++ b/docs/templating_vars.yaml
@@ -5,4 +5,5 @@ helm:
 versions:
   commons: 0.0.0-dev
   secret: 0.0.0-dev
+  listener: 0.0.0-dev
   zookeeper: 0.0.0-dev


### PR DESCRIPTION
# Description

The listener-operator is now one of the fundamental operators, along with the commons- and secret-operators, and should be mentioned accordingly everywhere.

Add changes from https://github.com/stackabletech/zookeeper-operator/commit/9d394bbb79bd89e80cc8ad56dd631dde0544950c#diff-b22263413919527a13ab1db697e5ea76d2541ed5a5be96fb903bbb8529c63c1b to the template file.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [x] Documentation added or updated
- [ ] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
