### PR TITLE
chore: bump operator-rs to 0.60.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ All notable changes to this project will be documented in this file.
 
 - More CRD documentation ([#749]).
 
+### Changed
+
+- Use new label builders ([#757]).
+- Use explicit match arms for AuthenticationClassProvider ([#757]).
+
+### Removed
+
+- [BREAKING] Removed legacy node selector on roleGroups ([#757]).
+
 [#749]: https://github.com/stackabletech/zookeeper-operator/pull/749
+[#757]: https://github.com/stackabletech/zookeeper-operator/pull/757
 
 ## [23.11.0] - 2023-11-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,12 +708,6 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -864,22 +869,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1067,7 +1062,7 @@ dependencies = [
  "backoff",
  "derivative",
  "futures 0.3.28",
- "hashbrown 0.14.0",
+ "hashbrown",
  "json-patch",
  "k8s-openapi",
  "kube-client",
@@ -1227,47 +1222,13 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-jaeger"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876958ba9084f390f913fcf04ddf7bbbb822898867bb0a51cc28f2b9e5c1b515"
-dependencies = [
- "async-trait",
  "futures-core",
- "futures-util",
- "opentelemetry",
- "opentelemetry-semantic-conventions",
- "thrift",
- "tokio",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
-dependencies = [
- "opentelemetry",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
+ "futures-sink",
+ "indexmap",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -1276,22 +1237,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry_sdk"
+name = "opentelemetry-jaeger"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
+checksum = "e617c66fd588e40e0dbbd66932fdc87393095b125d4459b1a3a10feb1712f8a1"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "thrift",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
- "opentelemetry_api",
- "ordered-float 3.9.1",
+ "opentelemetry",
+ "ordered-float 4.2.0",
  "percent-encoding",
  "rand",
- "regex",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1308,9 +1294,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "3.9.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
@@ -1824,7 +1810,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -1845,7 +1831,7 @@ version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -1973,12 +1959,13 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stackable-operator"
-version = "0.57.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.57.0#ab5c5c3f220ae9449e82f6861f44a4a9a6fb7b6b"
+version = "0.60.1"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.60.1#21f98e8937dac924e374b54bd6ea1d7b2367ca69"
 dependencies = [
  "chrono",
  "clap",
  "const_format",
+ "delegate",
  "derivative",
  "dockerfile-parser",
  "either",
@@ -1989,6 +1976,7 @@ dependencies = [
  "lazy_static",
  "opentelemetry",
  "opentelemetry-jaeger",
+ "opentelemetry_sdk",
  "product-config",
  "rand",
  "regex",
@@ -2005,12 +1993,13 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
 name = "stackable-operator-derive"
-version = "0.57.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.57.0#ab5c5c3f220ae9449e82f6861f44a4a9a6fb7b6b"
+version = "0.60.1"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.60.1#21f98e8937dac924e374b54bd6ea1d7b2367ca69"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2304,7 +2293,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2407,19 +2396,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-opentelemetry"
-version = "0.21.0"
+name = "tracing-log"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
+dependencies = [
+ "js-sys",
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -2437,7 +2439,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.3",
 ]
 
 [[package]]
@@ -2621,6 +2623,16 @@ name = "web-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["rust/crd", "rust/operator-binary"]
+resolver = "2"
 
 [workspace.package]
 version = "0.0.0-dev"
@@ -23,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 snafu = "0.7"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.57.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.60.1" }
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.6.0" }
 strum = { version = "0.25", features = ["derive"] }
 tokio = { version = "1.29", features = ["full"] }

--- a/deploy/helm/zookeeper-operator/crds/crds.yaml
+++ b/deploy/helm/zookeeper-operator/crds/crds.yaml
@@ -149,7 +149,7 @@ spec:
                       type: string
                   type: object
                 servers:
-                  description: This struct represents a role - e.g. HDFS datanodes or Trino workers. It has a [`HashMap`] containing all the roleGroups that are part of this role. Additionally, there is a `config`, which is configurable at the role *and* roleGroup level. Everything at roleGroup level is merged on top of what is configured on role level using the [`Merge`] trait. There is also a second form of config, which can only be configured at role level, the `roleConfig`.
+                  description: This struct represents a role - e.g. HDFS datanodes or Trino workers. It has a key-value-map containing all the roleGroups that are part of this role. Additionally, there is a `config`, which is configurable at the role *and* roleGroup level. Everything at roleGroup level is merged on top of what is configured on role level. There is also a second form of config, which can only be configured at role level, the `roleConfig`. You can learn more about this in the [Roles and role group concept documentation](https://docs.stackable.tech/home/nightly/concepts/roles-and-role-groups).
                   nullable: true
                   properties:
                     cliOverrides:
@@ -7160,37 +7160,6 @@ spec:
                             minimum: 0.0
                             nullable: true
                             type: integer
-                          selector:
-                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-                            nullable: true
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                    - key
-                                    - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
                         type: object
                       type: object
                   required:

--- a/rust/crd/src/affinity.rs
+++ b/rust/crd/src/affinity.rs
@@ -28,12 +28,9 @@ mod tests {
     use std::collections::BTreeMap;
 
     use stackable_operator::{
-        commons::affinity::{StackableAffinity, StackableNodeSelector},
+        commons::affinity::StackableAffinity,
         k8s_openapi::{
-            api::core::v1::{
-                NodeAffinity, NodeSelector, NodeSelectorRequirement, NodeSelectorTerm,
-                PodAffinityTerm, PodAntiAffinity, WeightedPodAffinityTerm,
-            },
+            api::core::v1::{PodAffinityTerm, PodAntiAffinity, WeightedPodAffinityTerm},
             apimachinery::pkg::apis::meta::v1::LabelSelector,
         },
         kube::runtime::reflector::ObjectRef,
@@ -106,106 +103,6 @@ mod tests {
 
             node_affinity: None,
             node_selector: None,
-        };
-
-        let affinity = zk
-            .merged_config(&ZookeeperRole::Server, &rolegroup_ref)
-            .unwrap()
-            .affinity;
-
-        assert_eq!(affinity, expected);
-    }
-
-    #[test]
-    fn test_affinity_legacy_node_selector() {
-        let input = r#"
-        apiVersion: zookeeper.stackable.tech/v1alpha1
-        kind: ZookeeperCluster
-        metadata:
-          name: simple-zk
-        spec:
-          image:
-            productVersion: 3.8.3
-          clusterConfig:
-            authentication:
-              - authenticationClass: zk-client-tls
-            tls:
-              serverSecretClass: tls
-              quorumSecretClass: tls
-          servers:
-            roleGroups:
-              default:
-                replicas: 3
-                selector:
-                  matchLabels:
-                    disktype: ssd
-                  matchExpressions:
-                    - key: topology.kubernetes.io/zone
-                      operator: In
-                      values:
-                        - antarctica-east1
-                        - antarctica-west1
-        "#;
-
-        let zk: ZookeeperCluster = serde_yaml::from_str(input).expect("illegal test input");
-
-        let expected: StackableAffinity = StackableAffinity {
-            node_affinity: Some(NodeAffinity {
-                preferred_during_scheduling_ignored_during_execution: None,
-                required_during_scheduling_ignored_during_execution: Some(NodeSelector {
-                    node_selector_terms: vec![NodeSelectorTerm {
-                        match_expressions: Some(vec![NodeSelectorRequirement {
-                            key: "topology.kubernetes.io/zone".to_string(),
-                            operator: "In".to_string(),
-                            values: Some(vec![
-                                "antarctica-east1".to_string(),
-                                "antarctica-west1".to_string(),
-                            ]),
-                        }]),
-                        match_fields: None,
-                    }],
-                }),
-            }),
-            node_selector: Some(StackableNodeSelector {
-                node_selector: BTreeMap::from([("disktype".to_string(), "ssd".to_string())]),
-            }),
-            pod_affinity: None,
-            pod_anti_affinity: Some(PodAntiAffinity {
-                required_during_scheduling_ignored_during_execution: None,
-                preferred_during_scheduling_ignored_during_execution: Some(vec![
-                    WeightedPodAffinityTerm {
-                        pod_affinity_term: PodAffinityTerm {
-                            label_selector: Some(LabelSelector {
-                                match_expressions: None,
-                                match_labels: Some(BTreeMap::from([
-                                    (
-                                        "app.kubernetes.io/name".to_string(),
-                                        "zookeeper".to_string(),
-                                    ),
-                                    (
-                                        "app.kubernetes.io/instance".to_string(),
-                                        "simple-zk".to_string(),
-                                    ),
-                                    (
-                                        "app.kubernetes.io/component".to_string(),
-                                        "server".to_string(),
-                                    ),
-                                ])),
-                            }),
-                            namespace_selector: None,
-                            namespaces: None,
-                            topology_key: "kubernetes.io/hostname".to_string(),
-                        },
-                        weight: 70,
-                    },
-                ]),
-            }),
-        };
-
-        let rolegroup_ref = RoleGroupRef {
-            cluster: ObjectRef::from_obj(&zk),
-            role: ZookeeperRole::Server.to_string(),
-            role_group: "default".to_string(),
         };
 
         let affinity = zk

--- a/rust/crd/src/authentication.rs
+++ b/rust/crd/src/authentication.rs
@@ -70,7 +70,9 @@ impl ResolvedAuthenticationClasses {
         for auth_class in &self.resolved_authentication_classes {
             match &auth_class.spec.provider {
                 AuthenticationClassProvider::Tls(_) => {}
-                _ => {
+                AuthenticationClassProvider::Ldap(_)
+                | AuthenticationClassProvider::Oidc(_)
+                | AuthenticationClassProvider::Static(_) => {
                     return Err(Error::AuthenticationMethodNotSupported {
                         authentication_class: ObjectRef::from_obj(auth_class),
                         method: auth_class.spec.provider.to_string(),

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -594,17 +594,6 @@ impl ZookeeperCluster {
         let role_group = self.rolegroup(rolegroup_ref)?;
         let mut conf_role_group = role_group.config.config;
 
-        if let Some(RoleGroup {
-            selector: Some(selector),
-            ..
-        }) = role.role_groups.get(&rolegroup_ref.role_group)
-        {
-            // Migrate old `selector` attribute, see ADR 26 affinities.
-            // TODO Can be removed after support for the old `selector` field is dropped.
-            #[allow(deprecated)]
-            conf_role_group.affinity.add_legacy_selector(selector);
-        }
-
         // Merge more specific configs into default config
         // Hierarchy is:
         // 1. RoleGroup

--- a/rust/crd/src/security.rs
+++ b/rust/crd/src/security.rs
@@ -257,7 +257,9 @@ impl ZookeeperSecurity {
             .get_tls_authentication_class()
             .and_then(|auth_class| match &auth_class.spec.provider {
                 AuthenticationClassProvider::Tls(tls) => tls.client_cert_secret_class.as_ref(),
-                _ => None,
+                AuthenticationClassProvider::Ldap(_)
+                | AuthenticationClassProvider::Oidc(_)
+                | AuthenticationClassProvider::Static(_) => None,
             })
             .or(self.server_secret_class.as_ref())
     }

--- a/rust/operator-binary/src/discovery.rs
+++ b/rust/operator-binary/src/discovery.rs
@@ -11,6 +11,8 @@ use stackable_zookeeper_crd::{security::ZookeeperSecurity, ZookeeperCluster, Zoo
 
 use crate::utils::build_recommended_labels;
 
+type Result<T, E = Error> = std::result::Result<T, E>;
+
 #[derive(Snafu, Debug)]
 pub enum Error {
     #[snafu(display("object {} is missing metadata to build owner reference", zk))]
@@ -113,7 +115,7 @@ fn build_discovery_configmap(
     chroot: Option<&str>,
     hosts: impl IntoIterator<Item = (impl Into<String>, u16)>,
     resolved_product_image: &ResolvedProductImage,
-) -> Result<ConfigMap, Error> {
+) -> Result<ConfigMap> {
     // Write a connection string of the format that Java ZooKeeper client expects:
     // "{host1}:{port1},{host2:port2},.../{chroot}"
     // See https://zookeeper.apache.org/doc/current/apidocs/zookeeper-server/org/apache/zookeeper/ZooKeeper.html#ZooKeeper-java.lang.String-int-org.apache.zookeeper.Watcher-
@@ -163,7 +165,7 @@ fn build_discovery_configmap(
 fn pod_hosts<'a>(
     zk: &'a ZookeeperCluster,
     zookeeper_security: &'a ZookeeperSecurity,
-) -> Result<impl IntoIterator<Item = (String, u16)> + 'a, Error> {
+) -> Result<impl IntoIterator<Item = (String, u16)> + 'a> {
     Ok(zk
         .pods()
         .context(ExpectedPodsSnafu)?
@@ -175,7 +177,7 @@ async fn nodeport_hosts(
     client: &stackable_operator::client::Client,
     svc: &Service,
     port_name: &str,
-) -> Result<impl IntoIterator<Item = (String, u16)>, Error> {
+) -> Result<impl IntoIterator<Item = (String, u16)>> {
     let svc_port = svc
         .spec
         .as_ref()

--- a/rust/operator-binary/src/discovery.rs
+++ b/rust/operator-binary/src/discovery.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeSet, num::TryFromIntError};
 
 use snafu::{OptionExt, ResultExt, Snafu};
 use stackable_operator::{
-    builder::{ConfigMapBuilder, ObjectMetaBuilder},
+    builder::{ConfigMapBuilder, ObjectMetaBuilder, ObjectMetaBuilderError},
     commons::product_image_selection::ResolvedProductImage,
     k8s_openapi::api::core::v1::{ConfigMap, Endpoints, Service},
     kube::{runtime::reflector::ObjectRef, Resource, ResourceExt},
@@ -54,6 +54,9 @@ pub enum Error {
     BuildConfigMap {
         source: stackable_operator::error::Error,
     },
+
+    #[snafu(display("failed to build object meta data"))]
+    ObjectMeta { source: ObjectMetaBuilderError },
 }
 
 /// Builds discovery [`ConfigMap`]s for connecting to a [`ZookeeperCluster`] for all expected scenarios
@@ -67,7 +70,7 @@ pub async fn build_discovery_configmaps(
     chroot: Option<&str>,
     resolved_product_image: &ResolvedProductImage,
     zookeeper_security: &ZookeeperSecurity,
-) -> Result<Vec<ConfigMap>, Error> {
+) -> Result<Vec<ConfigMap>> {
     let name = owner.name_unchecked();
     let namespace = owner.namespace().context(NoNamespaceSnafu)?;
 
@@ -147,6 +150,7 @@ fn build_discovery_configmap(
                     &ZookeeperRole::Server.to_string(),
                     "discovery",
                 ))
+                .context(ObjectMetaSnafu)?
                 .build(),
         )
         .add_data("ZOOKEEPER", conn_str)

--- a/rust/operator-binary/src/utils.rs
+++ b/rust/operator-binary/src/utils.rs
@@ -1,4 +1,4 @@
-use stackable_operator::labels::ObjectLabels;
+use stackable_operator::kvp::ObjectLabels;
 
 use crate::{APP_NAME, OPERATOR_NAME};
 


### PR DESCRIPTION
# Description

- **BREAKING** Removed legacy node selector on roleGroups.
- Use new label builders.
- Use explicit match arms for AuthorizationClassProvider ([as discussed](https://github.com/stackabletech/airflow-operator/pull/364#discussion_r1436810693))

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
