### PR TITLE
configOverrides are now able to overwrite configs written by the operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,17 @@ All notable changes to this project will be documented in this file.
 - Use new label builders ([#757]).
 - Use explicit match arms for AuthenticationClassProvider ([#757]).
 
+### Fixed
+
+- Apply configOverrides ([#762]).
+
 ### Removed
 
 - [BREAKING] Removed legacy node selector on roleGroups ([#757]).
 
 [#749]: https://github.com/stackabletech/zookeeper-operator/pull/749
 [#757]: https://github.com/stackabletech/zookeeper-operator/pull/757
+[#762]: https://github.com/stackabletech/zookeeper-operator/pull/762
 
 ## [23.11.0] - 2023-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Apply configOverrides ([#762]).
+- `configOverrides` are now able to overwrite configs written by the operator ([#762]).
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,6 +2036,7 @@ dependencies = [
  "rstest",
  "semver",
  "serde",
+ "serde_yaml",
  "snafu 0.7.5",
  "stackable-operator",
  "stackable-zookeeper-crd",

--- a/rust/crd/src/authentication.rs
+++ b/rust/crd/src/authentication.rs
@@ -83,6 +83,13 @@ impl ResolvedAuthenticationClasses {
 
         Ok(self.clone())
     }
+
+    /// USE ONLY IN TESTS! We can not put it behind `#[cfg(test)]` because of <https://github.com/rust-lang/cargo/issues/8379>
+    pub fn new_for_tests() -> Self {
+        ResolvedAuthenticationClasses {
+            resolved_authentication_classes: vec![],
+        }
+    }
 }
 
 /// Resolve provided AuthenticationClasses via API calls and validate the contents.

--- a/rust/crd/src/security.rs
+++ b/rust/crd/src/security.rs
@@ -279,4 +279,13 @@ impl ZookeeperSecurity {
 
         Ok(volume)
     }
+
+    /// USE ONLY IN TESTS! We can not put it behind `#[cfg(test)]` because of <https://github.com/rust-lang/cargo/issues/8379>
+    pub fn new_for_tests() -> Self {
+        ZookeeperSecurity {
+            resolved_authentication_classes: ResolvedAuthenticationClasses::new_for_tests(),
+            server_secret_class: Some("tls".to_owned()),
+            quorum_secret_class: "tls".to_string(),
+        }
+    }
 }

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -31,6 +31,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+serde_yaml.workspace = true
 
 [build-dependencies]
 built.workspace = true


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/zookeeper-operator/issues/761

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
