### PR TITLE
revert: zookeeper 3.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - More CRD documentation ([#749]).
 - Helm: support labels in values.yaml ([#763]).
 - Support for `3.8.4` ([#783])
-- Support for `3.9.2` ([#771], [#784]).
+- Support for `3.9.1` ([#771]).
 
 ### Changed
 
@@ -31,7 +31,6 @@ All notable changes to this project will be documented in this file.
 [#763]: https://github.com/stackabletech/zookeeper-operator/pull/763
 [#771]: https://github.com/stackabletech/zookeeper-operator/pull/771
 [#783]: https://github.com/stackabletech/zookeeper-operator/pull/783
-[#784]: https://github.com/stackabletech/zookeeper-operator/pull/784
 
 ## [23.11.0] - 2023-11-24
 

--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
@@ -67,7 +67,7 @@ zkCli_ls() {
 # tag::zkcli-ls[]
 kubectl run my-pod \
   --stdin --tty --quiet --restart=Never \
-  --image docker.stackable.tech/stackable/zookeeper:3.9.2-stackable0.0.0-dev -- \
+  --image docker.stackable.tech/stackable/zookeeper:3.9.1-stackable0.0.0-dev -- \
   bin/zkCli.sh -server simple-zk-server-default:2282 ls / > /dev/null && \
   kubectl logs my-pod && \
   kubectl delete pods my-pod

--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
@@ -67,7 +67,7 @@ zkCli_ls() {
 # tag::zkcli-ls[]
 kubectl run my-pod \
   --stdin --tty --quiet --restart=Never \
-  --image docker.stackable.tech/stackable/zookeeper:3.9.2-stackable{{ versions.zookeeper }} -- \
+  --image docker.stackable.tech/stackable/zookeeper:3.9.1-stackable{{ versions.zookeeper }} -- \
   bin/zkCli.sh -server simple-zk-server-default:2282 ls / > /dev/null && \
   kubectl logs my-pod && \
   kubectl delete pods my-pod

--- a/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml
+++ b/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.2
+    productVersion: 3.9.1
   servers:
     roleGroups:
       default:

--- a/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
@@ -7,7 +7,7 @@ spec:
   clusterConfig:
     listenerClass: external-unstable
   image:
-    productVersion: 3.9.2
+    productVersion: 3.9.1
   servers:
     roleGroups:
       default:

--- a/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-authentication.yaml
+++ b/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-authentication.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.2
+    productVersion: 3.9.1
   clusterConfig:
     authentication:
       - authenticationClass: zk-client-tls # <1>

--- a/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-encryption.yaml
+++ b/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-encryption.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.2
+    productVersion: 3.9.1
   clusterConfig:
     tls:
       serverSecretClass: tls # <1>

--- a/docs/modules/zookeeper/pages/reference/discovery.adoc
+++ b/docs/modules/zookeeper/pages/reference/discovery.adoc
@@ -26,7 +26,7 @@ The name of the ConfigMap created for this discovery profile is `$BASENAME-nodep
 
 Each discovery profile contains the following fields:
 
-`ZOOKEEPER`:: A connection string, as accepted by https://zookeeper.apache.org/doc/r3.9.2/apidocs/zookeeper-server/org/apache/zookeeper/ZooKeeper.html#ZooKeeper-java.lang.String-int-org.apache.zookeeper.Watcher-[the official Java client], e.g. `test-zk-server-default-0.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282,test-zk-server-default-1.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282/znode-4e169890-d2eb-4d62-9515-e4786f0ac58e`
+`ZOOKEEPER`:: A connection string, as accepted by https://zookeeper.apache.org/doc/r3.9.1/apidocs/zookeeper-server/org/apache/zookeeper/ZooKeeper.html#ZooKeeper-java.lang.String-int-org.apache.zookeeper.Watcher-[the official Java client], e.g. `test-zk-server-default-0.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282,test-zk-server-default-1.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282/znode-4e169890-d2eb-4d62-9515-e4786f0ac58e`
 `ZOOKEEPER_HOSTS`:: A comma-separated list of `node1:port1,node2:port2,...`, e.g. `test-zk-server-default-0.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282,test-zk-server-default-1.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282`
 `ZOOKEEPER_CHROOT`:: The name of the root ZNode associated with the discovery profile, should be used if (and only if) connecting using `ZOOKEEPER_HOSTS` (rather than `ZOOKEEPER`), e.g. `/znode-4e169890-d2eb-4d62-9515-e4786f0ac58e` in case of a ZNode discovery or `/` in case of a ZookeeperServer discovery
 `ZOOKEEPER_CLIENT_PORT`:: The port clients should use when connecting, e.g. `2282`

--- a/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/configuration_environment_overrides.adoc
@@ -39,7 +39,7 @@ servers:
 
 All property values must be strings.
 
-For a full list of configuration options we refer to the Apache ZooKeeper https://zookeeper.apache.org/doc/r3.9.2/zookeeperAdmin.html#sc_configuration[Configuration Reference].
+For a full list of configuration options we refer to the Apache ZooKeeper https://zookeeper.apache.org/doc/r3.9.1/zookeeperAdmin.html#sc_configuration[Configuration Reference].
 
 === Overriding entries in security.properties
 

--- a/docs/modules/zookeeper/pages/znodes.adoc
+++ b/docs/modules/zookeeper/pages/znodes.adoc
@@ -1,6 +1,6 @@
 = ZNodes
 
-Apache ZooKeeper organizes all data into a hierarchical system of https://zookeeper.apache.org/doc/r3.9.2/zookeeperProgrammers.html#ch_zkDataModel[ZNodes],
+Apache ZooKeeper organizes all data into a hierarchical system of https://zookeeper.apache.org/doc/r3.9.1/zookeeperProgrammers.html#ch_zkDataModel[ZNodes],
 which act as both files (they can have data associated with them) and folders (they can contain other ZNodes) when compared to a traditional (POSIX-like) file system.
 
 In order to isolate different clients using the same ZooKeeper cluster, each client application should be assigned a unique root ZNode, which it can then organize

--- a/docs/modules/zookeeper/partials/supported-versions.adoc
+++ b/docs/modules/zookeeper/partials/supported-versions.adoc
@@ -2,6 +2,6 @@
 // This is a separate file, since it is used by both the direct ZooKeeper documentation, and the overarching
 // Stackable Platform documentation.
 
-- 3.9.2
+- 3.9.1
 - 3.8.3 (deprecated)
 - 3.8.4 (LTS)

--- a/examples/simple-zookeeper-tls-cluster.yaml
+++ b/examples/simple-zookeeper-tls-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.2
+    productVersion: 3.9.1
   clusterConfig:
     authentication:
       - authenticationClass: zk-client-tls

--- a/rust/crd/src/affinity.rs
+++ b/rust/crd/src/affinity.rs
@@ -48,7 +48,7 @@ mod tests {
           name: simple-zk
         spec:
           image:
-            productVersion: 3.9.2
+            productVersion: 3.9.1
           clusterConfig:
             authentication:
               - authenticationClass: zk-client-tls

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -740,7 +740,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.2"
+            productVersion: "3.9.1"
         "#;
         let zookeeper: ZookeeperCluster = serde_yaml::from_str(input).expect("illegal test input");
         assert_eq!(
@@ -759,7 +759,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.2"
+            productVersion: "3.9.1"
           clusterConfig:
             tls:
               serverSecretClass: simple-zookeeper-client-tls
@@ -782,7 +782,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.2"
+            productVersion: "3.9.1"
           clusterConfig:
             tls:
               serverSecretClass: null
@@ -801,7 +801,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.2"
+            productVersion: "3.9.1"
           clusterConfig:
             tls:
               quorumSecretClass: simple-zookeeper-quorum-tls
@@ -826,7 +826,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.2"
+            productVersion: "3.9.1"
         "#;
         let zookeeper: ZookeeperCluster = serde_yaml::from_str(input).expect("illegal test input");
 
@@ -846,7 +846,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.2"
+            productVersion: "3.9.1"
           clusterConfig:
             tls:
               quorumSecretClass: simple-zookeeper-quorum-tls
@@ -868,7 +868,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.2"
+            productVersion: "3.9.1"
           clusterConfig:
             tls:
               serverSecretClass: simple-zookeeper-server-tls

--- a/rust/operator-binary/src/zk_controller.rs
+++ b/rust/operator-binary/src/zk_controller.rs
@@ -1021,7 +1021,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.2"
+            productVersion: "3.9.1"
           servers:
             roleGroups:
               default:
@@ -1048,7 +1048,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.2"
+            productVersion: "3.9.1"
           servers:
             configOverrides:
               zoo.cfg:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -4,10 +4,10 @@ dimensions:
     values:
       - 3.8.3
       - 3.8.4
-      - 3.9.2
+      - 3.9.1
   - name: zookeeper-latest
     values:
-      - 3.9.2
+      - 3.9.1
   - name: use-server-tls
     values:
       - "true"


### PR DESCRIPTION
# Description
This reverts commit 743f5054c09da803115e35e83ba2a64589ed8440 to roll back Zookeeper to 3.9.1 (undoing #784).

See https://github.com/stackabletech/docker-images/pull/595
