### PR TITLE
Removing zookeeper 3.8.3 as deprecated

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,7 +2,6 @@
 dimensions:
   - name: zookeeper
     values:
-      - 3.8.3
       - 3.8.4
       - 3.9.2
   - name: zookeeper-latest


### PR DESCRIPTION
# Description

Removing zookeeper 3.8.3 as it's not longer supported in 24.7

https://github.com/stackabletech/docker-images/pull/736 Removing from product

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
