### PR TITLE
chore: add oci references, merge templating changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,15 @@ All notable changes to this project will be documented in this file.
 - Run a `containerdebug` process in the background of each Zookeeper container to collect debugging information ([#881]).
 - Aggregate emitted Kubernetes events on the CustomResources ([#904]).
 
+
+### Changed
+
+- Default to OCI for image metadata and product image selection ([#905]).
+
 [#881]: https://github.com/stackabletech/zookeeper-operator/pull/881
 [#892]: https://github.com/stackabletech/zookeeper-operator/pull/892
 [#904]: https://github.com/stackabletech/zookeeper-operator/pull/904
+[#905]: https://github.com/stackabletech/zookeeper-operator/pull/905
 
 ## [24.11.1] - 2025-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ All notable changes to this project will be documented in this file.
 - Run a `containerdebug` process in the background of each Zookeeper container to collect debugging information ([#881]).
 - Aggregate emitted Kubernetes events on the CustomResources ([#904]).
 
-
 ### Changed
 
 - Default to OCI for image metadata and product image selection ([#905]).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,8 +2271,8 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stackable-operator"
-version = "0.84.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#b8fe43f7368249bf95b06d6cba3fd0135f7523ac"
+version = "0.85.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#59506c6202778889a27b6ae8153457e60a49c68d"
 dependencies = [
  "chrono",
  "clap",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=chore/docker-refs-to-oci#fc525b5dff25d5ea3fa57e762916f6233dc41879"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#59506c6202778889a27b6ae8153457e60a49c68d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2321,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=chore/docker-refs-to-oci#fc525b5dff25d5ea3fa57e762916f6233dc41879"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#59506c6202778889a27b6ae8153457e60a49c68d"
 dependencies = [
  "kube",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,7 +2272,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "stackable-operator"
 version = "0.84.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.0#af0d1f19d8770d346096a38c6dc82ba70e371039"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=chore/docker-refs-to-oci#fc525b5dff25d5ea3fa57e762916f6233dc41879"
 dependencies = [
  "chrono",
  "clap",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.0#af0d1f19d8770d346096a38c6dc82ba70e371039"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=chore/docker-refs-to-oci#fc525b5dff25d5ea3fa57e762916f6233dc41879"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2321,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.0#af0d1f19d8770d346096a38c6dc82ba70e371039"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=chore/docker-refs-to-oci#fc525b5dff25d5ea3fa57e762916f6233dc41879"
 dependencies = [
  "kube",
  "semver",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -7071,13 +7071,13 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.84.1";
+        version = "0.85.0";
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "b8fe43f7368249bf95b06d6cba3fd0135f7523ac";
-          sha256 = "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i";
+          rev = "59506c6202778889a27b6ae8153457e60a49c68d";
+          sha256 = "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5";
         };
         libName = "stackable_operator";
         authors = [
@@ -7236,8 +7236,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "b8fe43f7368249bf95b06d6cba3fd0135f7523ac";
-          sha256 = "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i";
+          rev = "59506c6202778889a27b6ae8153457e60a49c68d";
+          sha256 = "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -7271,8 +7271,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "b8fe43f7368249bf95b06d6cba3fd0135f7523ac";
-          sha256 = "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i";
+          rev = "59506c6202778889a27b6ae8153457e60a49c68d";
+          sha256 = "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5";
         };
         libName = "stackable_shared";
         authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 snafu = "0.8"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.84.0" }
+#stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.84.0" }
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.7.0" }
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.40", features = ["full"] }
@@ -31,7 +31,7 @@ tokio-zookeeper = "0.4"
 tracing = "0.1"
 
 #[patch."https://github.com/stackabletech/operator-rs.git"]
-#stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
+stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "chore/docker-refs-to-oci" }
 
 [patch.crates-io]
 # tokio-zookeeper = { path = "../tokio-zookeeper" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,15 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 snafu = "0.8"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.84.1" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.85.0" }
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.7.0" }
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.40", features = ["full"] }
 tokio-zookeeper = "0.4"
 tracing = "0.1"
 
-[patch."https://github.com/stackabletech/operator-rs.git"]
-stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "chore/docker-refs-to-oci" }
+# [patch."https://github.com/stackabletech/operator-rs.git"]
+# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
 
 [patch.crates-io]
 # tokio-zookeeper = { path = "../tokio-zookeeper" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ tokio = { version = "1.40", features = ["full"] }
 tokio-zookeeper = "0.4"
 tracing = "0.1"
 
-# [patch."https://github.com/stackabletech/operator-rs.git"]
-# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
+#[patch."https://github.com/stackabletech/operator-rs.git"]
+#stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
 
 [patch.crates-io]
 # tokio-zookeeper = { path = "../tokio-zookeeper" }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,6 +1,6 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#stackable-operator-derive@0.3.1": "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#stackable-operator@0.84.1": "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#stackable-shared@0.0.1": "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#stackable-operator-derive@0.3.1": "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#stackable-operator@0.85.0": "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#stackable-shared@0.0.1": "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5",
   "git+https://github.com/stackabletech/product-config.git?tag=0.7.0#product-config@0.7.0": "0gjsm80g6r75pm3824dcyiz4ysq1ka4c1if6k1mjm9cnd5ym0gny"
 }

--- a/deploy/helm/zookeeper-operator/crds/crds.yaml
+++ b/deploy/helm/zookeeper-operator/crds/crds.yaml
@@ -123,7 +123,7 @@ spec:
                     Consult the [Product image selection documentation](https://docs.stackable.tech/home/nightly/concepts/product_image_selection) for details.
                   properties:
                     custom:
-                      description: Overwrite the docker image. Specify the full docker image name, e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`
+                      description: Overwrite the docker image. Specify the full docker image name, e.g. `oci.stackable.tech/sdp/superset:1.4.1-stackable2.1.0`
                       type: string
                     productVersion:
                       description: Version of the product, e.g. `1.4.1`.
@@ -150,7 +150,7 @@ spec:
                       nullable: true
                       type: array
                     repo:
-                      description: Name of the docker repo, e.g. `docker.stackable.tech/stackable`
+                      description: Name of the docker repo, e.g. `oci.stackable.tech/sdp`
                       nullable: true
                       type: string
                     stackableVersion:

--- a/deploy/helm/zookeeper-operator/values.yaml
+++ b/deploy/helm/zookeeper-operator/values.yaml
@@ -1,7 +1,7 @@
 # Default values for zookeeper-operator.
 ---
 image:
-  repository: docker.stackable.tech/stackable/zookeeper-operator
+  repository: oci.stackable.tech/sdp/zookeeper-operator
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
@@ -70,7 +70,7 @@ zkCli_ls() {
 # tag::zkcli-ls[]
 kubectl run my-pod \
   --stdin --tty --quiet --restart=Never \
-  --image docker.stackable.tech/stackable/zookeeper:3.9.2-stackable0.0.0-dev -- \
+  --image oci.stackable.tech/sdp/zookeeper:3.9.2-stackable0.0.0-dev -- \
   bin/zkCli.sh -server simple-zk-server-default:2282 ls / > /dev/null && \
   kubectl logs my-pod && \
   kubectl delete pods my-pod

--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
@@ -70,7 +70,7 @@ zkCli_ls() {
 # tag::zkcli-ls[]
 kubectl run my-pod \
   --stdin --tty --quiet --restart=Never \
-  --image docker.stackable.tech/stackable/zookeeper:3.9.2-stackable{{ versions.zookeeper }} -- \
+  --image oci.stackable.tech/sdp/zookeeper:3.9.2-stackable{{ versions.zookeeper }} -- \
   bin/zkCli.sh -server simple-zk-server-default:2282 ls / > /dev/null && \
   kubectl logs my-pod && \
   kubectl delete pods my-pod

--- a/docs/modules/zookeeper/pages/reference/environment-variables.adoc
+++ b/docs/modules/zookeeper/pages/reference/environment-variables.adoc
@@ -30,7 +30,7 @@ docker run \
 --env KUBECONFIG=/home/stackable/.kube/config \
 --env KUBERNETES_CLUSTER_DOMAIN=mycluster.local \
 --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-docker.stackable.tech/stackable/zookeeper-operator:latest
+oci.stackable.tech/sdp/zookeeper-operator:0.0.0-dev
 ----
 
 == PRODUCT_CONFIG
@@ -56,7 +56,7 @@ docker run \
     --env KUBECONFIG=/home/stackable/.kube/config \
     --env PRODUCT_CONFIG=/my/product/config.yaml \
     --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-    docker.stackable.tech/stackable/zookeeper-operator:latest
+    oci.stackable.tech/sdp/zookeeper-operator:0.0.0-dev
 ----
 
 == WATCH_NAMESPACE
@@ -85,5 +85,5 @@ docker run \
 --env KUBECONFIG=/home/stackable/.kube/config \
 --env WATCH_NAMESPACE=test \
 --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-docker.stackable.tech/stackable/zookeeper-operator:latest
+oci.stackable.tech/sdp/zookeeper-operator:0.0.0-dev
 ----

--- a/tests/templates/kuttl/logging/20-install-check.yaml
+++ b/tests/templates/kuttl/logging/20-install-check.yaml
@@ -29,6 +29,6 @@ spec:
     spec:
       containers:
         - name: zk-test-helper
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           stdin: true
           tty: true

--- a/tests/templates/kuttl/smoke/20-install-check.yaml
+++ b/tests/templates/kuttl/smoke/20-install-check.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: zk-test-helper
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           stdin: true
           tty: true
           resources:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,12 +2,12 @@
 dimensions:
   - name: zookeeper
     values:
-      - 3.9.2,oci.stackable.tech/sdp/zookeeper:3.9.2-stackable0.0.0-dev
+      - 3.9.2
       # To use a custom image, add a comma and the full name after the product version
       # - 3.9.2,oci.stackable.tech/sdp/zookeeper:3.9.2-stackable0.0.0-dev
   - name: zookeeper-latest
     values:
-      - 3.9.2,oci.stackable.tech/sdp/zookeeper:3.9.2-stackable0.0.0-dev
+      - 3.9.2
       # To use a custom image, add a comma and the full name after the product version
       # - 3.9.2,oci.stackable.tech/sdp/zookeeper:3.9.2-stackable0.0.0-dev
   - name: use-server-tls

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,14 +2,14 @@
 dimensions:
   - name: zookeeper
     values:
-      - 3.9.2
+      - 3.9.2,oci.stackable.tech/sdp/zookeeper:3.9.2-stackable0.0.0-dev
       # To use a custom image, add a comma and the full name after the product version
-      # - 3.9.2,docker.stackable.tech/stackable/zookeeper:3.9.2-stackable0.0.0-dev
+      # - 3.9.2,oci.stackable.tech/sdp/zookeeper:3.9.2-stackable0.0.0-dev
   - name: zookeeper-latest
     values:
-      - 3.9.2
+      - 3.9.2,oci.stackable.tech/sdp/zookeeper:3.9.2-stackable0.0.0-dev
       # To use a custom image, add a comma and the full name after the product version
-      # - 3.9.2,docker.stackable.tech/stackable/zookeeper:3.9.2-stackable0.0.0-dev
+      # - 3.9.2,oci.stackable.tech/sdp/zookeeper:3.9.2-stackable0.0.0-dev
   - name: use-server-tls
     values:
       - "true"


### PR DESCRIPTION
# Description

- [x] merge templating PR
- [x] change all references, use search-and-replace to find things (Makefile, Dockerfiles, operator Helm Charts, default,nix, kuttl tests, ....)
- [x] ensure that kuttl tests are running
- [x] for every image reference, ensure that the image is actually in Harbor (and image hash is the same as before?)

Openshift tests:

```
--- PASS: kuttl (266.91s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/znode_zookeeper-latest-3.9.2_openshift-true (43.55s)
        --- PASS: kuttl/harness/logging_zookeeper-3.9.2_openshift-true (82.56s)
        --- PASS: kuttl/harness/cluster-operation_zookeeper-latest-3.9.2_openshift-true (59.73s)
        --- PASS: kuttl/harness/delete-rolegroup_zookeeper-3.9.2_openshift-true (92.59s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.2_use-server-tls-true_use-client-auth-tls-true_openshift-true (175.48s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
