### PR TITLE
fix: Use `json` file extension for log files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ All notable changes to this project will be documented in this file.
     and is now set by `ROLLING_LOGS` (or via `--rolling-logs <DIRECTORY>`).
   - Replace stackable-operator `print_startup_string` with `tracing::info!` with fields.
 
+### Fixed
+
+- Use `json` file extension for log files ([#932]).
+
 [#927]: https://github.com/stackabletech/zookeeper-operator/pull/927
+[#932]: https://github.com/stackabletech/zookeeper-operator/pull/932
 
 ## [25.3.0] - 2025-03-21
 

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -89,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
                     Settings::builder()
                         .with_environment_variable(ENV_VAR_CONSOLE_LOG)
                         .with_default_level(LevelFilter::INFO)
-                        .file_log_settings_builder(log_directory, "tracing-rs.log")
+                        .file_log_settings_builder(log_directory, "tracing-rs.json")
                         .with_rotation_period(rotation_period)
                         .build()
                 }))


### PR DESCRIPTION
This was accidentally broken by work done in https://github.com/stackabletech/issues/issues/639 but before https://github.com/stackabletech/operator-rs/pull/1001 could be rolled out (which does use the correct file extension).