### PR TITLE
chore: Remove ZooKeeper 3.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,16 @@ All notable changes to this project will be documented in this file.
 
 - Use `json` file extension for log files ([#932]).
 
+### Removed
+
+- test: ZooKeeper 2.9.2 removed ([#940]).
+
 [#927]: https://github.com/stackabletech/zookeeper-operator/pull/927
 [#933]: https://github.com/stackabletech/zookeeper-operator/pull/934
 [#932]: https://github.com/stackabletech/zookeeper-operator/pull/932
 [#934]: https://github.com/stackabletech/zookeeper-operator/pull/934
 [#938]: https://github.com/stackabletech/zookeeper-operator/pull/938
+[#940]: https://github.com/stackabletech/zookeeper-operator/pull/940
 
 ## [25.3.0] - 2025-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
-- test: ZooKeeper 3.9.2 removed ([#940]).
+- Remove support for ZooKeeper 3.9.2 ([#940]).
 
 [#927]: https://github.com/stackabletech/zookeeper-operator/pull/927
 [#933]: https://github.com/stackabletech/zookeeper-operator/pull/934

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
-- test: ZooKeeper 2.9.2 removed ([#940]).
+- test: ZooKeeper 3.9.2 removed ([#940]).
 
 [#927]: https://github.com/stackabletech/zookeeper-operator/pull/927
 [#933]: https://github.com/stackabletech/zookeeper-operator/pull/934

--- a/docs/modules/zookeeper/partials/supported-versions.adoc
+++ b/docs/modules/zookeeper/partials/supported-versions.adoc
@@ -2,5 +2,4 @@
 // This is a separate file, since it is used by both the direct ZooKeeper documentation, and the overarching
 // Stackable Platform documentation.
 
-- 3.9.2 (Deprecated)
 - 3.9.3 (LTS)

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,7 +2,6 @@
 dimensions:
   - name: zookeeper
     values:
-      - 3.9.2
       - 3.9.3
       # To use a custom image, add a comma and the full name after the product version
       # - 3.9.3,oci.stackable.tech/sdp/zookeeper:3.9.3-stackable0.0.0-dev


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1083.

- Remove ZooKeeper 2.9.2 from tests and docs

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

# Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

# Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
