### PR TITLE
chore: Remove hardcoded uid and gid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to this project will be documented in this file.
     of having the operator write it to the vector config ([#933]).
 - test: Bump to Vector 0.46.1 ([#942]).
 - Use versioned common structs ([#946]).
+- BREAKING: Previously this operator would hardcode the UID and GID of the Pods being created to 1000/0, this has changed now ([#950])
+  - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
+  - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
+  - This is marked as breaking because tools and policies might exist, which require these fields to be set
 
 ### Fixed
 
@@ -40,6 +44,7 @@ All notable changes to this project will be documented in this file.
 [#940]: https://github.com/stackabletech/zookeeper-operator/pull/940
 [#942]: https://github.com/stackabletech/zookeeper-operator/pull/942
 [#946]: https://github.com/stackabletech/zookeeper-operator/pull/946
+[#950]: https://github.com/stackabletech/zookeeper-operator/pull/950
 
 ## [25.3.0] - 2025-03-21
 

--- a/rust/operator-binary/src/zk_controller.rs
+++ b/rust/operator-binary/src/zk_controller.rs
@@ -86,7 +86,6 @@ use crate::{
 pub const ZK_CONTROLLER_NAME: &str = "zookeepercluster";
 pub const ZK_FULL_CONTROLLER_NAME: &str = concatcp!(ZK_CONTROLLER_NAME, '.', OPERATOR_NAME);
 
-pub const ZK_UID: i64 = 1000;
 pub struct Ctx {
     pub client: stackable_operator::client::Client,
     pub product_config: ProductConfigManager,
@@ -955,8 +954,6 @@ fn build_server_rolegroup_statefulset(
         )
         .context(AddVolumeSnafu)?
         .security_context(PodSecurityContext {
-            run_as_user: Some(ZK_UID),
-            run_as_group: Some(0),
             fs_group: Some(1000),
             ..PodSecurityContext::default()
         })


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/651

Remove hardcoded uid and gid, they'll default to the ones from the docker images now.
For 25.7 that means they might change from 1000/0
See https://github.com/stackabletech/docker-images/pull/916 for details

## Definition of Done Checklist


### Author

- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] Changelog updated

### Acceptance

- [ ] Proper release label has been added
