### PR TITLE
chore: add built-in Prometheus support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project will be documented in this file.
   - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
   - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
   - This is marked as breaking because tools and policies might exist, which require these fields to be set
+- BREAKING: Replace JMX Exporter with built in Prometheus support. Hence, the metrics provided by the `/metrics` endpoint are named
+    differently now ([#955]).
 
 ### Fixed
 
@@ -45,6 +47,7 @@ All notable changes to this project will be documented in this file.
 [#942]: https://github.com/stackabletech/zookeeper-operator/pull/942
 [#946]: https://github.com/stackabletech/zookeeper-operator/pull/946
 [#950]: https://github.com/stackabletech/zookeeper-operator/pull/950
+[#955]: https://github.com/stackabletech/zookeeper-operator/pull/955
 
 ## [25.3.0] - 2025-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
   - Use `--file-log-max-files` (or `FILE_LOG_MAX_FILES`) to limit the number of log files kept.
   - Use `--file-log-rotation-period` (or `FILE_LOG_ROTATION_PERIOD`) to configure the frequency of rotation.
   - Use `--console-log-format` (or `CONSOLE_LOG_FORMAT`) to set the format to `plain` (default) or `json`.
+- Add built-in Prometheus support and expose metrics on `/metrics` path of `native-metrics` port ([#955]).
 
 ### Changed
 
@@ -27,8 +28,6 @@ All notable changes to this project will be documented in this file.
   - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
   - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
   - This is marked as breaking because tools and policies might exist, which require these fields to be set
-- BREAKING: Replace JMX Exporter with built in Prometheus support. Hence, the metrics provided by the `/metrics` endpoint are named
-    differently now ([#955]).
 
 ### Fixed
 

--- a/docs/modules/zookeeper/pages/usage_guide/monitoring.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/monitoring.adoc
@@ -2,4 +2,23 @@
 :description: The managed ZooKeeper instances are automatically configured to export Prometheus metrics.
 
 The managed ZooKeeper instances are automatically configured to export Prometheus metrics.
-See xref:operators:monitoring.adoc[] for more details.
+See xref:operators:monitoring.adoc[window=_blank] for more details.
+
+Depending on the SDP version, different ZooKeeper monitoring systems are used to produce metrics.
+Previously, JMX in combination with JMX Exporter was used. Starting with SDP 25.7 the New Metrics System is utilized.
+The naming of the metrics differs between the two systems.
+
+== ZooKeeper New Metrics System
+
+Since SDP 25.7 ZooKeeper is configured to provide metrics by utilizing the New Metrics System. More on the New Metrics System in
+the https://zookeeper.apache.org/doc/current/zookeeperMonitor.html[ZooKeeper Monitor Guide,window=_blank].
+
+The configuration is located in the `zoo.cfg`:
+
+[source,properties]
+----
+metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider
+metricsProvider.httpPort=9505
+----
+
+The metrics can be accessed by calling the `/metrics` endpoint on the specified port.

--- a/docs/modules/zookeeper/pages/usage_guide/monitoring.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/monitoring.adoc
@@ -4,13 +4,13 @@
 The managed ZooKeeper instances are automatically configured to export Prometheus metrics.
 See xref:operators:monitoring.adoc[window=_blank] for more details.
 
-Depending on the SDP version, different ZooKeeper monitoring systems are used to produce metrics.
-Previously, JMX in combination with JMX Exporter was used. Starting with SDP 25.7 the New Metrics System is utilized.
+Depending on the SDP version, different ZooKeeper monitoring systems are used to produce metrics. Currently, JMX in combination with JMX Exporter
+is used, but will be removed in a later release. Starting with SDP 25.7 the built-in Prometheus support of ZooKeeper is also added.
 The naming of the metrics differs between the two systems.
 
 == Metrics
 
-Starting with SDP 25.7 ZooKeeper is configured to export metrics using the built in Prometheus provider. More on the Prometheus provider in
+Starting with SDP 25.7 ZooKeeper is configured to export metrics using the built-in Prometheus provider. More on the Prometheus provider in
 the https://zookeeper.apache.org/doc/current/zookeeperMonitor.html[ZooKeeper Monitor Guide,window=_blank].
 
 The configuration is located in the `zoo.cfg`:
@@ -18,7 +18,7 @@ The configuration is located in the `zoo.cfg`:
 [source,properties]
 ----
 metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider
-metricsProvider.httpPort=9505
+metricsProvider.httpPort=7000
 ----
 
 The metrics can be accessed by calling the `/metrics` endpoint on the specified port.

--- a/docs/modules/zookeeper/pages/usage_guide/monitoring.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/monitoring.adoc
@@ -8,9 +8,9 @@ Depending on the SDP version, different ZooKeeper monitoring systems are used to
 Previously, JMX in combination with JMX Exporter was used. Starting with SDP 25.7 the New Metrics System is utilized.
 The naming of the metrics differs between the two systems.
 
-== ZooKeeper New Metrics System
+== Metrics
 
-Since SDP 25.7 ZooKeeper is configured to provide metrics by utilizing the New Metrics System. More on the New Metrics System in
+Starting with SDP 25.7 ZooKeeper is configured to export metrics using the built in Prometheus provider. More on the Prometheus provider in
 the https://zookeeper.apache.org/doc/current/zookeeperMonitor.html[ZooKeeper Monitor Guide,window=_blank].
 
 The configuration is located in the `zoo.cfg`:

--- a/rust/operator-binary/src/config/jvm.rs
+++ b/rust/operator-binary/src/config/jvm.rs
@@ -6,7 +6,7 @@ use stackable_operator::{
 
 use crate::crd::{
     JVM_SECURITY_PROPERTIES_FILE, LOG4J_CONFIG_FILE, LOGBACK_CONFIG_FILE, LoggingFramework,
-    METRICS_PORT, STACKABLE_CONFIG_DIR, STACKABLE_LOG_CONFIG_DIR,
+    STACKABLE_CONFIG_DIR, STACKABLE_LOG_CONFIG_DIR,
     v1alpha1::{ZookeeperCluster, ZookeeperConfig, ZookeeperConfigFragment},
 };
 
@@ -36,9 +36,6 @@ fn construct_jvm_args(
 
     let jvm_args = vec![
         format!("-Djava.security.properties={STACKABLE_CONFIG_DIR}/{JVM_SECURITY_PROPERTIES_FILE}"),
-        format!(
-            "-javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar={METRICS_PORT}:/stackable/jmx/server.yaml"
-        ),
         match logging_framework {
             LoggingFramework::LOG4J => {
                 format!("-Dlog4j.configuration=file:{STACKABLE_LOG_CONFIG_DIR}/{LOG4J_CONFIG_FILE}")
@@ -123,7 +120,6 @@ mod tests {
         assert_eq!(
             non_heap_jvm_args,
             "-Djava.security.properties=/stackable/config/security.properties \
-            -javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar=9505:/stackable/jmx/server.yaml \
             -Dlogback.configurationFile=/stackable/log_config/logback.xml"
         );
         assert_eq!(zk_server_heap_env, "409");
@@ -168,7 +164,6 @@ mod tests {
         assert_eq!(
             non_heap_jvm_args,
             "-Djava.security.properties=/stackable/config/security.properties \
-            -javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar=9505:/stackable/jmx/server.yaml \
             -Dlogback.configurationFile=/stackable/log_config/logback.xml \
             -Dhttps.proxyHost=proxy.my.corp \
             -Djava.net.preferIPv4Stack=true \

--- a/rust/operator-binary/src/config/jvm.rs
+++ b/rust/operator-binary/src/config/jvm.rs
@@ -6,7 +6,7 @@ use stackable_operator::{
 
 use crate::crd::{
     JVM_SECURITY_PROPERTIES_FILE, LOG4J_CONFIG_FILE, LOGBACK_CONFIG_FILE, LoggingFramework,
-    STACKABLE_CONFIG_DIR, STACKABLE_LOG_CONFIG_DIR,
+    METRICS_PORT, STACKABLE_CONFIG_DIR, STACKABLE_LOG_CONFIG_DIR,
     v1alpha1::{ZookeeperCluster, ZookeeperConfig, ZookeeperConfigFragment},
 };
 
@@ -36,6 +36,9 @@ fn construct_jvm_args(
 
     let jvm_args = vec![
         format!("-Djava.security.properties={STACKABLE_CONFIG_DIR}/{JVM_SECURITY_PROPERTIES_FILE}"),
+        format!(
+            "-javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar={METRICS_PORT}:/stackable/jmx/server.yaml"
+        ),
         match logging_framework {
             LoggingFramework::LOG4J => {
                 format!("-Dlog4j.configuration=file:{STACKABLE_LOG_CONFIG_DIR}/{LOG4J_CONFIG_FILE}")
@@ -120,6 +123,7 @@ mod tests {
         assert_eq!(
             non_heap_jvm_args,
             "-Djava.security.properties=/stackable/config/security.properties \
+            -javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar=9505:/stackable/jmx/server.yaml \
             -Dlogback.configurationFile=/stackable/log_config/logback.xml"
         );
         assert_eq!(zk_server_heap_env, "409");
@@ -164,6 +168,7 @@ mod tests {
         assert_eq!(
             non_heap_jvm_args,
             "-Djava.security.properties=/stackable/config/security.properties \
+            -javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar=9505:/stackable/jmx/server.yaml \
             -Dlogback.configurationFile=/stackable/log_config/logback.xml \
             -Dhttps.proxyHost=proxy.my.corp \
             -Djava.net.preferIPv4Stack=true \

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -47,8 +47,9 @@ pub const OPERATOR_NAME: &str = "zookeeper.stackable.tech";
 pub const ZOOKEEPER_PROPERTIES_FILE: &str = "zoo.cfg";
 pub const JVM_SECURITY_PROPERTIES_FILE: &str = "security.properties";
 
+pub const METRICS_PORT: u16 = 9505;
 pub const METRICS_PROVIDER_HTTP_PORT_KEY: &str = "metricsProvider.httpPort";
-pub const METRICS_PROVIDER_HTTP_PORT: u16 = 9505;
+pub const METRICS_PROVIDER_HTTP_PORT: u16 = 7000;
 
 pub const STACKABLE_DATA_DIR: &str = "/stackable/data";
 pub const STACKABLE_CONFIG_DIR: &str = "/stackable/config";

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -47,7 +47,9 @@ pub const OPERATOR_NAME: &str = "zookeeper.stackable.tech";
 pub const ZOOKEEPER_PROPERTIES_FILE: &str = "zoo.cfg";
 pub const JVM_SECURITY_PROPERTIES_FILE: &str = "security.properties";
 
-pub const METRICS_PORT: u16 = 9505;
+pub const METRICS_PROVIDER_CLASS_NAME: &str =
+    "org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider";
+pub const METRICS_PROVIDER_HTTP_PORT: u16 = 9505;
 
 pub const STACKABLE_DATA_DIR: &str = "/stackable/data";
 pub const STACKABLE_CONFIG_DIR: &str = "/stackable/config";
@@ -371,6 +373,8 @@ impl v1alpha1::ZookeeperConfig {
     pub const DATA_DIR: &'static str = "dataDir";
     const DEFAULT_SECRET_LIFETIME: Duration = Duration::from_days_unchecked(1);
     pub const INIT_LIMIT: &'static str = "initLimit";
+    const METRICS_PROVIDER_CLASS_NAME: &'static str = "metricsProvider.className";
+    const METRICS_PROVIDER_HTTP_PORT: &'static str = "metricsProvider.httpPort";
     pub const MYID_OFFSET: &'static str = "MYID_OFFSET";
     pub const SYNC_LIMIT: &'static str = "syncLimit";
     pub const TICK_TIME: &'static str = "tickTime";
@@ -467,6 +471,14 @@ impl Configuration for v1alpha1::ZookeeperConfigFragment {
             result.insert(
                 v1alpha1::ZookeeperConfig::DATA_DIR.to_string(),
                 Some(STACKABLE_DATA_DIR.to_string()),
+            );
+            result.insert(
+                v1alpha1::ZookeeperConfig::METRICS_PROVIDER_CLASS_NAME.to_string(),
+                Some(METRICS_PROVIDER_CLASS_NAME.to_string()),
+            );
+            result.insert(
+                v1alpha1::ZookeeperConfig::METRICS_PROVIDER_HTTP_PORT.to_string(),
+                Some(METRICS_PROVIDER_HTTP_PORT.to_string()),
             );
         }
 

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -47,8 +47,7 @@ pub const OPERATOR_NAME: &str = "zookeeper.stackable.tech";
 pub const ZOOKEEPER_PROPERTIES_FILE: &str = "zoo.cfg";
 pub const JVM_SECURITY_PROPERTIES_FILE: &str = "security.properties";
 
-pub const METRICS_PROVIDER_CLASS_NAME: &str =
-    "org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider";
+pub const METRICS_PROVIDER_HTTP_PORT_KEY: &str = "metricsProvider.httpPort";
 pub const METRICS_PROVIDER_HTTP_PORT: u16 = 9505;
 
 pub const STACKABLE_DATA_DIR: &str = "/stackable/data";
@@ -373,8 +372,6 @@ impl v1alpha1::ZookeeperConfig {
     pub const DATA_DIR: &'static str = "dataDir";
     const DEFAULT_SECRET_LIFETIME: Duration = Duration::from_days_unchecked(1);
     pub const INIT_LIMIT: &'static str = "initLimit";
-    const METRICS_PROVIDER_CLASS_NAME: &'static str = "metricsProvider.className";
-    const METRICS_PROVIDER_HTTP_PORT: &'static str = "metricsProvider.httpPort";
     pub const MYID_OFFSET: &'static str = "MYID_OFFSET";
     pub const SYNC_LIMIT: &'static str = "syncLimit";
     pub const TICK_TIME: &'static str = "tickTime";
@@ -473,11 +470,13 @@ impl Configuration for v1alpha1::ZookeeperConfigFragment {
                 Some(STACKABLE_DATA_DIR.to_string()),
             );
             result.insert(
-                v1alpha1::ZookeeperConfig::METRICS_PROVIDER_CLASS_NAME.to_string(),
-                Some(METRICS_PROVIDER_CLASS_NAME.to_string()),
+                "metricsProvider.className".to_string(),
+                Some(
+                    "org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider".to_string(),
+                ),
             );
             result.insert(
-                v1alpha1::ZookeeperConfig::METRICS_PROVIDER_HTTP_PORT.to_string(),
+                METRICS_PROVIDER_HTTP_PORT_KEY.to_string(),
                 Some(METRICS_PROVIDER_HTTP_PORT.to_string()),
             );
         }

--- a/rust/operator-binary/src/zk_controller.rs
+++ b/rust/operator-binary/src/zk_controller.rs
@@ -715,6 +715,12 @@ fn build_server_rolegroup_service(
             },
             ServicePort {
                 name: Some("metrics".to_string()),
+                port: 9505,
+                protocol: Some("TCP".to_string()),
+                ..ServicePort::default()
+            },
+            ServicePort {
+                name: Some("native-metrics".to_string()),
                 port: metrics_port_from_rolegroup_config(rolegroup_config).into(),
                 protocol: Some("TCP".to_string()),
                 ..ServicePort::default()
@@ -900,8 +906,9 @@ fn build_server_rolegroup_statefulset(
         .add_container_port("zk", zookeeper_security.client_port().into())
         .add_container_port("zk-leader", 2888)
         .add_container_port("zk-election", 3888)
+        .add_container_port("metrics", 9505)
         .add_container_port(
-            "metrics",
+            "native-metrics",
             metrics_port_from_rolegroup_config(server_config).into(),
         )
         .add_volume_mount("data", STACKABLE_DATA_DIR)

--- a/rust/operator-binary/src/zk_controller.rs
+++ b/rust/operator-binary/src/zk_controller.rs
@@ -72,8 +72,9 @@ use crate::{
     config::jvm::{construct_non_heap_jvm_args, construct_zk_server_heap_env},
     crd::{
         DOCKER_IMAGE_BASE_NAME, JVM_SECURITY_PROPERTIES_FILE, MAX_PREPARE_LOG_FILE_SIZE,
-        MAX_ZK_LOG_FILES_SIZE, STACKABLE_CONFIG_DIR, STACKABLE_DATA_DIR, STACKABLE_LOG_CONFIG_DIR,
-        STACKABLE_LOG_DIR, STACKABLE_RW_CONFIG_DIR, ZOOKEEPER_PROPERTIES_FILE, ZookeeperRole,
+        MAX_ZK_LOG_FILES_SIZE, METRICS_PROVIDER_HTTP_PORT, METRICS_PROVIDER_HTTP_PORT_KEY,
+        STACKABLE_CONFIG_DIR, STACKABLE_DATA_DIR, STACKABLE_LOG_CONFIG_DIR, STACKABLE_LOG_DIR,
+        STACKABLE_RW_CONFIG_DIR, ZOOKEEPER_PROPERTIES_FILE, ZookeeperRole,
         security::{self, ZookeeperSecurity},
         v1alpha1,
     },
@@ -415,6 +416,7 @@ pub async fn reconcile_zk(
             &rolegroup,
             &resolved_product_image,
             &zookeeper_security,
+            rolegroup_config,
         )?;
         let rg_configmap = build_server_rolegroup_config_map(
             zk,
@@ -675,6 +677,7 @@ fn build_server_rolegroup_service(
     rolegroup: &RoleGroupRef<v1alpha1::ZookeeperCluster>,
     resolved_product_image: &ResolvedProductImage,
     zookeeper_security: &ZookeeperSecurity,
+    rolegroup_config: &HashMap<PropertyNameKind, BTreeMap<String, String>>,
 ) -> Result<Service> {
     let prometheus_label =
         Label::try_from(("prometheus.io/scrape", "true")).context(BuildLabelSnafu)?;
@@ -712,7 +715,7 @@ fn build_server_rolegroup_service(
             },
             ServicePort {
                 name: Some("metrics".to_string()),
-                port: 9505,
+                port: metrics_port_from_rolegroup_config(rolegroup_config).into(),
                 protocol: Some("TCP".to_string()),
                 ..ServicePort::default()
             },
@@ -897,7 +900,10 @@ fn build_server_rolegroup_statefulset(
         .add_container_port("zk", zookeeper_security.client_port().into())
         .add_container_port("zk-leader", 2888)
         .add_container_port("zk-election", 3888)
-        .add_container_port("metrics", 9505)
+        .add_container_port(
+            "metrics",
+            metrics_port_from_rolegroup_config(server_config).into(),
+        )
         .add_volume_mount("data", STACKABLE_DATA_DIR)
         .context(AddVolumeMountSnafu)?
         .add_volume_mount("config", STACKABLE_CONFIG_DIR)
@@ -1061,6 +1067,27 @@ fn build_server_rolegroup_statefulset(
         spec: Some(statefulset_spec),
         status: None,
     })
+}
+
+fn metrics_port_from_rolegroup_config(
+    rolegroup_config: &HashMap<PropertyNameKind, BTreeMap<String, String>>,
+) -> u16 {
+    let metrics_port = rolegroup_config
+        .get(&PropertyNameKind::File(
+            ZOOKEEPER_PROPERTIES_FILE.to_string(),
+        ))
+        .expect("{ZOOKEEPER_PROPERTIES_FILE} is present")
+        .get(METRICS_PROVIDER_HTTP_PORT_KEY)
+        .expect("{METRICS_PROVIDER_HTTP_PORT_KEY} is set");
+
+    match u16::from_str(metrics_port) {
+        Ok(port) => port,
+        Err(err) => {
+            tracing::error!("{err}");
+            tracing::info!("Defaulting to using {METRICS_PROVIDER_HTTP_PORT} as metrics port.");
+            METRICS_PROVIDER_HTTP_PORT
+        }
+    }
 }
 
 pub fn error_policy(

--- a/tests/templates/kuttl/smoke/test_zookeeper.py
+++ b/tests/templates/kuttl/smoke/test_zookeeper.py
@@ -64,6 +64,12 @@ def check_monitoring(hosts):
         response = try_get(url)
 
         if response.ok:
+            # arbitrary metric was chosen to test if metrics are present in the response
+            if "quorum_size" in response.text:
+                continue
+            else:
+                print("Error for [" + url + "]: missing metrics")
+                exit(-1)
             continue
         else:
             print("Error for [" + url + "]: could not access monitoring")

--- a/tests/templates/kuttl/smoke/test_zookeeper.py
+++ b/tests/templates/kuttl/smoke/test_zookeeper.py
@@ -3,6 +3,7 @@ import argparse
 import requests
 import time
 import sys
+
 sys.tracebacklimit = 0
 
 
@@ -37,18 +38,29 @@ def check_ruok(hosts):
         url = host + ":8080/commands/" + cmd_ruok
         response = try_get(url).json()
 
-        if "command" in response and response["command"] == cmd_ruok \
-                and "error" in response and response["error"] is None:
+        if (
+            "command" in response
+            and response["command"] == cmd_ruok
+            and "error" in response
+            and response["error"] is None
+        ):
             continue
         else:
-            print("Error[" + cmd_ruok + "] for [" + url + "]: received " + str(
-                response) + " - expected {'command': 'ruok', 'error': None} ")
+            print(
+                "Error["
+                + cmd_ruok
+                + "] for ["
+                + url
+                + "]: received "
+                + str(response)
+                + " - expected {'command': 'ruok', 'error': None} "
+            )
             exit(-1)
 
 
 def check_monitoring(hosts):
     for host in hosts:
-        url = host + ":9505"
+        url = host + ":9505/metrics"
         response = try_get(url)
 
         if response.ok:
@@ -58,15 +70,29 @@ def check_monitoring(hosts):
             exit(-1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     all_args = argparse.ArgumentParser(description="Test ZooKeeper.")
-    all_args.add_argument("-n", "--namespace", help="The namespace to run in", required=True)
+    all_args.add_argument(
+        "-n", "--namespace", help="The namespace to run in", required=True
+    )
     args = vars(all_args.parse_args())
     namespace = args["namespace"]
 
-    host_primary_0 = "http://test-zk-server-primary-0.test-zk-server-primary." + namespace + ".svc.cluster.local"
-    host_primary_1 = "http://test-zk-server-primary-1.test-zk-server-primary." + namespace + ".svc.cluster.local"
-    host_secondary = "http://test-zk-server-secondary-0.test-zk-server-secondary." + namespace + ".svc.cluster.local"
+    host_primary_0 = (
+        "http://test-zk-server-primary-0.test-zk-server-primary."
+        + namespace
+        + ".svc.cluster.local"
+    )
+    host_primary_1 = (
+        "http://test-zk-server-primary-1.test-zk-server-primary."
+        + namespace
+        + ".svc.cluster.local"
+    )
+    host_secondary = (
+        "http://test-zk-server-secondary-0.test-zk-server-secondary."
+        + namespace
+        + ".svc.cluster.local"
+    )
 
     hosts = [host_primary_0, host_primary_1, host_secondary]
 

--- a/tests/templates/kuttl/smoke/test_zookeeper.py
+++ b/tests/templates/kuttl/smoke/test_zookeeper.py
@@ -60,7 +60,18 @@ def check_ruok(hosts):
 
 def check_monitoring(hosts):
     for host in hosts:
-        url = host + ":9505/metrics"
+        # test for the jmx exporter metrics
+        url = host + ":9505"
+        response = try_get(url)
+
+        if response.ok:
+            continue
+        else:
+            print("Error for [" + url + "]: could not access monitoring")
+            exit(-1)
+
+        # test for the native metrics
+        url = host + ":7000/metrics"
         response = try_get(url)
 
         if response.ok:


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/zookeeper-operator/issues/954

Docs added here: https://docs.stackable.tech/home/nightly/zookeeper/usage_guide/monitoring/

## Integrationtests

```
--- PASS: kuttl (292.82s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_zookeeper-latest-3.9.3_openshift-false (33.82s)
        --- PASS: kuttl/harness/znode_zookeeper-latest-3.9.3_openshift-false (28.00s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.3_use-server-tls-false_use-client-auth-tls-false_openshift-false (72.61s)
        --- PASS: kuttl/harness/delete-rolegroup_zookeeper-3.9.3_openshift-false (68.26s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.3_use-server-tls-true_use-client-auth-tls-true_openshift-false (136.65s)
        --- PASS: kuttl/harness/logging_zookeeper-3.9.3_openshift-false (68.04s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.3_use-server-tls-true_use-client-auth-tls-false_openshift-false (78.36s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.3_use-server-tls-false_use-client-auth-tls-true_openshift-false (83.90s)
PASS
```

Openshift
```
--- PASS: kuttl (136.25s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/znode_zookeeper-latest-3.9.3_openshift-true (33.86s)
        --- PASS: kuttl/harness/logging_zookeeper-3.9.3_openshift-true (41.60s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.3_use-server-tls-true_use-client-auth-tls-true_openshift-true (101.50s)
        --- PASS: kuttl/harness/delete-rolegroup_zookeeper-3.9.3_openshift-true (34.16s)
        --- PASS: kuttl/harness/cluster-operation_zookeeper-latest-3.9.3_openshift-true (33.89s)
PASS
```

## Release Note Snippet
Prometheus support was added using the built-in Prometheus provider in ZooKeeper. This appends another port (`native-metrics`). To access the metrics this port in combination with the `/metrics` endpoint can be used.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
- [x] Links to generated (nightly) docs added
- [x] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
