### PR TITLE
fix(docs): Update getting-started script pre-25.7.0

### DIFF
--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
@@ -64,7 +64,7 @@ zkCli_ls() {
 kubectl run my-pod \
   --stdin --tty --quiet --restart=Never \
   --image oci.stackable.tech/sdp/zookeeper:3.9.3-stackable0.0.0-dev -- \
-  bin/zkCli.sh -server simple-zk-server-default:2282 ls / > /dev/null && \
+  bin/zkCli.sh -server simple-zk-server:2282 ls / > /dev/null && \
   kubectl logs my-pod && \
   kubectl delete pods my-pod
 # end::zkcli-ls[]

--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
@@ -64,7 +64,7 @@ zkCli_ls() {
 kubectl run my-pod \
   --stdin --tty --quiet --restart=Never \
   --image oci.stackable.tech/sdp/zookeeper:3.9.3-stackable{{ versions.zookeeper }} -- \
-  bin/zkCli.sh -server simple-zk-server-default:2282 ls / > /dev/null && \
+  bin/zkCli.sh -server simple-zk-server:2282 ls / > /dev/null && \
   kubectl logs my-pod && \
   kubectl delete pods my-pod
 # end::zkcli-ls[]

--- a/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml
+++ b/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml
@@ -8,7 +8,7 @@ spec:
     productVersion: 3.9.3
   servers:
     roleConfig:
-      listenerClass: external-unstable
+      listenerClass: cluster-internal
     roleGroups:
       default:
         replicas: 3

--- a/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml
+++ b/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml
@@ -4,11 +4,11 @@ kind: ZookeeperCluster
 metadata:
   name: simple-zk
 spec:
-  clusterConfig:
-    listenerClass: external-unstable
   image:
     productVersion: 3.9.3
   servers:
+    roleConfig:
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 3

--- a/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
@@ -8,7 +8,7 @@ spec:
     productVersion: 3.9.3
   servers:
     roleConfig:
-      listenerClass: external-unstable
+      listenerClass: cluster-internal
     roleGroups:
       default:
         replicas: 3

--- a/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
@@ -4,11 +4,11 @@ kind: ZookeeperCluster
 metadata:
   name: simple-zk
 spec:
-  clusterConfig:
-    listenerClass: external-unstable
   image:
     productVersion: 3.9.3
   servers:
+    roleConfig:
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 3


### PR DESCRIPTION
- Move `listenerClass` to under roleConfig.
- Move to `cluster-internal` listener class.
- Update the service name (no longer at the rolegroup level)

## Check and Update Getting Started Script

Part of <https://github.com/stackabletech/issues/issues/742>

> [!NOTE]
> During a Stackable release we need to check (and optionally update) the
> getting-started scripts to ensure they still work after product and operator
> updates.

```shell
# Some of the scripts are in a code/ subdirectory
# pushd docs/modules/superset/examples/getting_started
# pushd docs/modules/superset/examples/getting_started/code
pushd $(fd -td getting_started | grep examples); cd code 2>/dev/null || true

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm

popd
```
