### PR TITLE
chore: Bump zookeeper version for 25.11.0

### DIFF
--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
@@ -63,7 +63,7 @@ zkCli_ls() {
 # tag::zkcli-ls[]
 kubectl run my-pod \
   --stdin --tty --quiet --restart=Never \
-  --image oci.stackable.tech/sdp/zookeeper:3.9.3-stackable0.0.0-dev -- \
+  --image oci.stackable.tech/sdp/zookeeper:3.9.4-stackable0.0.0-dev -- \
   bin/zkCli.sh -server simple-zk-server:2282 ls / > /dev/null && \
   kubectl logs my-pod && \
   kubectl delete pods my-pod

--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
@@ -63,7 +63,7 @@ zkCli_ls() {
 # tag::zkcli-ls[]
 kubectl run my-pod \
   --stdin --tty --quiet --restart=Never \
-  --image oci.stackable.tech/sdp/zookeeper:3.9.3-stackable{{ versions.zookeeper }} -- \
+  --image oci.stackable.tech/sdp/zookeeper:3.9.4-stackable{{ versions.zookeeper }} -- \
   bin/zkCli.sh -server simple-zk-server:2282 ls / > /dev/null && \
   kubectl logs my-pod && \
   kubectl delete pods my-pod

--- a/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml
+++ b/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleConfig:
       listenerClass: cluster-internal

--- a/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleConfig:
       listenerClass: cluster-internal

--- a/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-authentication.yaml
+++ b/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-authentication.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   clusterConfig:
     authentication:
       - authenticationClass: zk-client-tls # <1>

--- a/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-encryption.yaml
+++ b/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-encryption.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   clusterConfig:
     tls:
       serverSecretClass: tls # <1>

--- a/docs/modules/zookeeper/partials/supported-versions.adoc
+++ b/docs/modules/zookeeper/partials/supported-versions.adoc
@@ -2,4 +2,5 @@
 // This is a separate file, since it is used by both the direct ZooKeeper documentation, and the overarching
 // Stackable Platform documentation.
 
-- 3.9.3 (LTS)
+- 3.9.4 (LTS)
+- 3.9.3 (deprecated)

--- a/examples/simple-zookeeper-tls-cluster.yaml
+++ b/examples/simple-zookeeper-tls-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   clusterConfig:
     authentication:
       - authenticationClass: zk-client-tls

--- a/rust/operator-binary/src/config/jvm.rs
+++ b/rust/operator-binary/src/config/jvm.rs
@@ -117,7 +117,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.3"
+            productVersion: "3.9.4"
           servers:
             roleGroups:
               default:
@@ -152,7 +152,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.3"
+            productVersion: "3.9.4"
           servers:
             config:
               resources:

--- a/rust/operator-binary/src/crd/affinity.rs
+++ b/rust/operator-binary/src/crd/affinity.rs
@@ -48,7 +48,7 @@ mod tests {
           name: simple-zk
         spec:
           image:
-            productVersion: 3.9.3
+            productVersion: 3.9.4
           clusterConfig:
             authentication:
               - authenticationClass: zk-client-tls

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -729,7 +729,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.3"
+            productVersion: "3.9.4"
         "#;
         let zookeeper: v1alpha1::ZookeeperCluster =
             serde_yaml::from_str(input).expect("illegal test input");
@@ -749,7 +749,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.3"
+            productVersion: "3.9.4"
           clusterConfig:
             tls:
               serverSecretClass: simple-zookeeper-client-tls
@@ -773,7 +773,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.3"
+            productVersion: "3.9.4"
           clusterConfig:
             tls:
               serverSecretClass: null
@@ -793,7 +793,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.3"
+            productVersion: "3.9.4"
           clusterConfig:
             tls:
               quorumSecretClass: simple-zookeeper-quorum-tls
@@ -819,7 +819,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.3"
+            productVersion: "3.9.4"
         "#;
         let zookeeper: v1alpha1::ZookeeperCluster =
             serde_yaml::from_str(input).expect("illegal test input");
@@ -840,7 +840,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.3"
+            productVersion: "3.9.4"
           clusterConfig:
             tls:
               quorumSecretClass: simple-zookeeper-quorum-tls
@@ -863,7 +863,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.3"
+            productVersion: "3.9.4"
           clusterConfig:
             tls:
               serverSecretClass: simple-zookeeper-server-tls

--- a/rust/operator-binary/src/zk_controller.rs
+++ b/rust/operator-binary/src/zk_controller.rs
@@ -1225,7 +1225,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.3"
+            productVersion: "3.9.4"
           servers:
             roleGroups:
               default:
@@ -1252,7 +1252,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.3"
+            productVersion: "3.9.4"
           servers:
             configOverrides:
               zoo.cfg:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -3,11 +3,12 @@ dimensions:
   - name: zookeeper
     values:
       - 3.9.3
+      - 3.9.4
       # To use a custom image, add a comma and the full name after the product version
       # - 3.9.3,oci.stackable.tech/sdp/zookeeper:3.9.3-stackable0.0.0-dev
   - name: zookeeper-latest
     values:
-      - 3.9.3
+      - 3.9.4
       # To use a custom image, add a comma and the full name after the product version
       # - 3.9.3,oci.stackable.tech/sdp/zookeeper:3.9.3-stackable0.0.0-dev
   - name: use-server-tls


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/docker-images/issues/1275

### Integrationtests

```
--- PASS: kuttl (435.02s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_zookeeper-latest-3.9.4_openshift-false (45.99s)
        --- PASS: kuttl/harness/logging_zookeeper-3.9.4_openshift-false (126.46s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4_use-server-tls-false_use-client-auth-tls-true_openshift-false (153.68s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4_use-server-tls-true_use-client-auth-tls-true_openshift-false (125.88s)
        --- PASS: kuttl/harness/znode_zookeeper-latest-3.9.4_openshift-false (32.33s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4_use-server-tls-true_use-client-auth-tls-false_openshift-false (143.80s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.4_use-server-tls-false_use-client-auth-tls-false_openshift-false (108.12s)
        --- PASS: kuttl/harness/delete-rolegroup_zookeeper-3.9.4_openshift-false (91.53s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
