### PR TITLE
fix: split fetch and validate auth class steps

### DIFF
--- a/rust/operator-binary/src/crd/authentication.rs
+++ b/rust/operator-binary/src/crd/authentication.rs
@@ -51,19 +51,19 @@ pub mod versioned {
 }
 
 #[derive(Clone, Debug)]
-/// Helper struct that contains resolved AuthenticationClasses to reduce network API calls.
-pub struct ResolvedAuthenticationClasses {
+/// Helper struct that contains dereferenced AuthenticationClasses to reduce network API calls.
+pub struct DereferencedAuthenticationClasses {
     resolved_authentication_classes: Vec<core::v1alpha1::AuthenticationClass>,
 }
 
-impl ResolvedAuthenticationClasses {
+impl DereferencedAuthenticationClasses {
     /// Fetch the referenced AuthenticationClasses from the Kubernetes API without validating them.
     ///
     /// Call [`Self::validate`] on the result to enforce the constraints documented there.
     pub async fn fetch_references(
         client: &Client,
         auth_classes: &Vec<v1alpha1::ZookeeperAuthentication>,
-    ) -> Result<ResolvedAuthenticationClasses, Error> {
+    ) -> Result<DereferencedAuthenticationClasses, Error> {
         let mut resolved_authentication_classes: Vec<core::v1alpha1::AuthenticationClass> = vec![];
 
         for auth_class in auth_classes {
@@ -81,7 +81,7 @@ impl ResolvedAuthenticationClasses {
             );
         }
 
-        Ok(ResolvedAuthenticationClasses {
+        Ok(DereferencedAuthenticationClasses {
             resolved_authentication_classes,
         })
     }
@@ -96,7 +96,7 @@ impl ResolvedAuthenticationClasses {
         })
     }
 
-    /// Validates the resolved AuthenticationClasses.
+    /// Validates the dereferenced AuthenticationClasses.
     /// Currently errors out if:
     /// - More than one AuthenticationClass was provided
     /// - AuthenticationClass mechanism was not supported
@@ -125,7 +125,7 @@ impl ResolvedAuthenticationClasses {
 
     /// USE ONLY IN TESTS! We can not put it behind `#[cfg(test)]` because of <https://github.com/rust-lang/cargo/issues/8379>
     pub fn new_for_tests() -> Self {
-        ResolvedAuthenticationClasses {
+        DereferencedAuthenticationClasses {
             resolved_authentication_classes: vec![],
         }
     }

--- a/rust/operator-binary/src/crd/authentication.rs
+++ b/rust/operator-binary/src/crd/authentication.rs
@@ -57,6 +57,35 @@ pub struct ResolvedAuthenticationClasses {
 }
 
 impl ResolvedAuthenticationClasses {
+    /// Fetch the referenced AuthenticationClasses from the Kubernetes API without validating them.
+    ///
+    /// Call [`Self::validate`] on the result to enforce the constraints documented there.
+    pub async fn fetch_references(
+        client: &Client,
+        auth_classes: &Vec<v1alpha1::ZookeeperAuthentication>,
+    ) -> Result<ResolvedAuthenticationClasses, Error> {
+        let mut resolved_authentication_classes: Vec<core::v1alpha1::AuthenticationClass> = vec![];
+
+        for auth_class in auth_classes {
+            resolved_authentication_classes.push(
+                core::v1alpha1::AuthenticationClass::resolve(
+                    client,
+                    &auth_class.authentication_class,
+                )
+                .await
+                .context(AuthenticationClassRetrievalSnafu {
+                    authentication_class: ObjectRef::<core::v1alpha1::AuthenticationClass>::new(
+                        &auth_class.authentication_class,
+                    ),
+                })?,
+            );
+        }
+
+        Ok(ResolvedAuthenticationClasses {
+            resolved_authentication_classes,
+        })
+    }
+
     /// Return the (first) TLS `AuthenticationClass` if available
     pub fn get_tls_authentication_class(&self) -> Option<&core::v1alpha1::AuthenticationClass> {
         self.resolved_authentication_classes.iter().find(|auth| {
@@ -100,32 +129,4 @@ impl ResolvedAuthenticationClasses {
             resolved_authentication_classes: vec![],
         }
     }
-}
-
-/// Resolve provided AuthenticationClasses via API calls and validate the contents.
-/// Currently errors out if:
-/// - AuthenticationClass could not be resolved
-/// - Validation failed
-pub async fn resolve_authentication_classes(
-    client: &Client,
-    auth_classes: &Vec<v1alpha1::ZookeeperAuthentication>,
-) -> Result<ResolvedAuthenticationClasses, Error> {
-    let mut resolved_authentication_classes: Vec<core::v1alpha1::AuthenticationClass> = vec![];
-
-    for auth_class in auth_classes {
-        resolved_authentication_classes.push(
-            core::v1alpha1::AuthenticationClass::resolve(client, &auth_class.authentication_class)
-                .await
-                .context(AuthenticationClassRetrievalSnafu {
-                    authentication_class: ObjectRef::<core::v1alpha1::AuthenticationClass>::new(
-                        &auth_class.authentication_class,
-                    ),
-                })?,
-        );
-    }
-
-    ResolvedAuthenticationClasses {
-        resolved_authentication_classes,
-    }
-    .validate()
 }

--- a/rust/operator-binary/src/crd/authentication.rs
+++ b/rust/operator-binary/src/crd/authentication.rs
@@ -53,7 +53,7 @@ pub mod versioned {
 #[derive(Clone, Debug)]
 /// Helper struct that contains dereferenced AuthenticationClasses to reduce network API calls.
 pub struct DereferencedAuthenticationClasses {
-    resolved_authentication_classes: Vec<core::v1alpha1::AuthenticationClass>,
+    dereferenced_authentication_classes: Vec<core::v1alpha1::AuthenticationClass>,
 }
 
 impl DereferencedAuthenticationClasses {
@@ -64,10 +64,11 @@ impl DereferencedAuthenticationClasses {
         client: &Client,
         auth_classes: &Vec<v1alpha1::ZookeeperAuthentication>,
     ) -> Result<DereferencedAuthenticationClasses, Error> {
-        let mut resolved_authentication_classes: Vec<core::v1alpha1::AuthenticationClass> = vec![];
+        let mut dereferenced_authentication_classes: Vec<core::v1alpha1::AuthenticationClass> =
+            vec![];
 
         for auth_class in auth_classes {
-            resolved_authentication_classes.push(
+            dereferenced_authentication_classes.push(
                 core::v1alpha1::AuthenticationClass::resolve(
                     client,
                     &auth_class.authentication_class,
@@ -82,18 +83,20 @@ impl DereferencedAuthenticationClasses {
         }
 
         Ok(DereferencedAuthenticationClasses {
-            resolved_authentication_classes,
+            dereferenced_authentication_classes,
         })
     }
 
     /// Return the (first) TLS `AuthenticationClass` if available
     pub fn get_tls_authentication_class(&self) -> Option<&core::v1alpha1::AuthenticationClass> {
-        self.resolved_authentication_classes.iter().find(|auth| {
-            matches!(
-                auth.spec.provider,
-                core::v1alpha1::AuthenticationClassProvider::Tls(_)
-            )
-        })
+        self.dereferenced_authentication_classes
+            .iter()
+            .find(|auth| {
+                matches!(
+                    auth.spec.provider,
+                    core::v1alpha1::AuthenticationClassProvider::Tls(_)
+                )
+            })
     }
 
     /// Validates the dereferenced AuthenticationClasses.
@@ -101,11 +104,11 @@ impl DereferencedAuthenticationClasses {
     /// - More than one AuthenticationClass was provided
     /// - AuthenticationClass mechanism was not supported
     pub fn validate(&self) -> Result<Self, Error> {
-        if self.resolved_authentication_classes.len() > 1 {
+        if self.dereferenced_authentication_classes.len() > 1 {
             return Err(Error::MultipleAuthenticationClassesProvided);
         }
 
-        for auth_class in &self.resolved_authentication_classes {
+        for auth_class in &self.dereferenced_authentication_classes {
             match &auth_class.spec.provider {
                 core::v1alpha1::AuthenticationClassProvider::Tls(_) => {}
                 core::v1alpha1::AuthenticationClassProvider::Ldap(_)
@@ -126,7 +129,7 @@ impl DereferencedAuthenticationClasses {
     /// USE ONLY IN TESTS! We can not put it behind `#[cfg(test)]` because of <https://github.com/rust-lang/cargo/issues/8379>
     pub fn new_for_tests() -> Self {
         DereferencedAuthenticationClasses {
-            resolved_authentication_classes: vec![],
+            dereferenced_authentication_classes: vec![],
         }
     }
 }

--- a/rust/operator-binary/src/crd/security.rs
+++ b/rust/operator-binary/src/crd/security.rs
@@ -26,7 +26,7 @@ use stackable_operator::{
 };
 
 use crate::{
-    crd::{authentication::ResolvedAuthenticationClasses, tls, v1alpha1},
+    crd::{authentication::DereferencedAuthenticationClasses, tls, v1alpha1},
     zk_controller::LISTENER_VOLUME_NAME,
 };
 
@@ -51,7 +51,7 @@ pub enum Error {
 
 /// Helper struct combining TLS settings for server and quorum with the resolved AuthenticationClasses
 pub struct ZookeeperSecurity {
-    resolved_authentication_classes: ResolvedAuthenticationClasses,
+    resolved_authentication_classes: DereferencedAuthenticationClasses,
     server_secret_class: Option<String>,
     quorum_secret_class: String,
 }
@@ -90,11 +90,11 @@ impl ZookeeperSecurity {
     pub const SYSTEM_TRUST_STORE_DIR: &'static str = "/etc/pki/java/cacerts";
 
     /// Build a `ZookeeperSecurity` from a [`v1alpha1::ZookeeperCluster`] and already-resolved
-    /// [`ResolvedAuthenticationClasses`]. Synchronous; intended to be called from the validate
+    /// [`DereferencedAuthenticationClasses`]. Synchronous; intended to be called from the validate
     /// step of the controllers.
     pub fn new(
         zk: &v1alpha1::ZookeeperCluster,
-        resolved_authentication_classes: ResolvedAuthenticationClasses,
+        resolved_authentication_classes: DereferencedAuthenticationClasses,
     ) -> Self {
         ZookeeperSecurity {
             resolved_authentication_classes,
@@ -351,7 +351,7 @@ impl ZookeeperSecurity {
     /// USE ONLY IN TESTS! We can not put it behind `#[cfg(test)]` because of <https://github.com/rust-lang/cargo/issues/8379>
     pub fn new_for_tests() -> Self {
         ZookeeperSecurity {
-            resolved_authentication_classes: ResolvedAuthenticationClasses::new_for_tests(),
+            resolved_authentication_classes: DereferencedAuthenticationClasses::new_for_tests(),
             server_secret_class: Some("tls".to_owned()),
             quorum_secret_class: "tls".to_string(),
         }

--- a/rust/operator-binary/src/zk_controller/dereference.rs
+++ b/rust/operator-binary/src/zk_controller/dereference.rs
@@ -9,7 +9,7 @@ use snafu::{ResultExt, Snafu};
 use stackable_operator::client::Client;
 
 use crate::crd::{
-    authentication::{self, ResolvedAuthenticationClasses},
+    authentication::{self, DereferencedAuthenticationClasses},
     v1alpha1,
 };
 
@@ -24,7 +24,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// Kubernetes objects referenced from the [`v1alpha1::ZookeeperCluster`] spec, already fetched but
 /// not yet validated.
 pub struct DereferencedObjects {
-    pub authentication_classes: ResolvedAuthenticationClasses,
+    pub authentication_classes: DereferencedAuthenticationClasses,
 }
 
 /// Fetches all Kubernetes objects referenced from the [`v1alpha1::ZookeeperCluster`] spec.
@@ -32,7 +32,7 @@ pub async fn dereference(
     client: &Client,
     zk: &v1alpha1::ZookeeperCluster,
 ) -> Result<DereferencedObjects> {
-    let authentication_classes = ResolvedAuthenticationClasses::fetch_references(
+    let authentication_classes = DereferencedAuthenticationClasses::fetch_references(
         client,
         &zk.spec.cluster_config.authentication,
     )

--- a/rust/operator-binary/src/zk_controller/dereference.rs
+++ b/rust/operator-binary/src/zk_controller/dereference.rs
@@ -24,7 +24,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// Kubernetes objects referenced from the [`v1alpha1::ZookeeperCluster`] spec, already fetched but
 /// not yet validated.
 pub struct DereferencedObjects {
-    pub resolved_authentication_classes: ResolvedAuthenticationClasses,
+    pub authentication_classes: ResolvedAuthenticationClasses,
 }
 
 /// Fetches all Kubernetes objects referenced from the [`v1alpha1::ZookeeperCluster`] spec.
@@ -32,7 +32,7 @@ pub async fn dereference(
     client: &Client,
     zk: &v1alpha1::ZookeeperCluster,
 ) -> Result<DereferencedObjects> {
-    let resolved_authentication_classes = ResolvedAuthenticationClasses::fetch_references(
+    let authentication_classes = ResolvedAuthenticationClasses::fetch_references(
         client,
         &zk.spec.cluster_config.authentication,
     )
@@ -40,6 +40,6 @@ pub async fn dereference(
     .context(FetchAuthenticationClassesSnafu)?;
 
     Ok(DereferencedObjects {
-        resolved_authentication_classes,
+        authentication_classes,
     })
 }

--- a/rust/operator-binary/src/zk_controller/dereference.rs
+++ b/rust/operator-binary/src/zk_controller/dereference.rs
@@ -15,13 +15,14 @@ use crate::crd::{
 
 #[derive(Snafu, Debug)]
 pub enum Error {
-    #[snafu(display("failed to resolve authentication classes"))]
-    ResolveAuthenticationClasses { source: authentication::Error },
+    #[snafu(display("failed to fetch authentication classes"))]
+    FetchAuthenticationClasses { source: authentication::Error },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Kubernetes objects referenced from the [`v1alpha1::ZookeeperCluster`] spec, already fetched.
+/// Kubernetes objects referenced from the [`v1alpha1::ZookeeperCluster`] spec, already fetched but
+/// not yet validated.
 pub struct DereferencedObjects {
     pub resolved_authentication_classes: ResolvedAuthenticationClasses,
 }
@@ -31,12 +32,12 @@ pub async fn dereference(
     client: &Client,
     zk: &v1alpha1::ZookeeperCluster,
 ) -> Result<DereferencedObjects> {
-    let resolved_authentication_classes = authentication::resolve_authentication_classes(
+    let resolved_authentication_classes = ResolvedAuthenticationClasses::fetch_references(
         client,
         &zk.spec.cluster_config.authentication,
     )
     .await
-    .context(ResolveAuthenticationClassesSnafu)?;
+    .context(FetchAuthenticationClassesSnafu)?;
 
     Ok(DereferencedObjects {
         resolved_authentication_classes,

--- a/rust/operator-binary/src/zk_controller/validate.rs
+++ b/rust/operator-binary/src/zk_controller/validate.rs
@@ -73,7 +73,7 @@ pub fn validate(
         .context(ResolveProductImageSnafu)?;
 
     let resolved_authentication_classes = dereferenced_objects
-        .resolved_authentication_classes
+        .authentication_classes
         .validate()
         .context(InvalidAuthenticationClassConfigurationSnafu)?;
 

--- a/rust/operator-binary/src/zk_controller/validate.rs
+++ b/rust/operator-binary/src/zk_controller/validate.rs
@@ -17,7 +17,7 @@ use stackable_operator::{
 use crate::{
     crd::{
         CONTAINER_IMAGE_BASE_NAME, JVM_SECURITY_PROPERTIES_FILE, ZOOKEEPER_PROPERTIES_FILE,
-        ZookeeperRole, security::ZookeeperSecurity, v1alpha1,
+        ZookeeperRole, authentication, security::ZookeeperSecurity, v1alpha1,
     },
     zk_controller::dereference::DereferencedObjects,
 };
@@ -28,6 +28,9 @@ pub enum Error {
     ResolveProductImage {
         source: product_image_selection::Error,
     },
+
+    #[snafu(display("failed to validate authentication classes"))]
+    InvalidAuthenticationClassConfiguration { source: authentication::Error },
 
     #[snafu(display("object defines no server role"))]
     NoServerRole,
@@ -69,10 +72,12 @@ pub fn validate(
         )
         .context(ResolveProductImageSnafu)?;
 
-    let zookeeper_security = ZookeeperSecurity::new(
-        zk,
-        dereferenced_objects.resolved_authentication_classes.clone(),
-    );
+    let resolved_authentication_classes = dereferenced_objects
+        .resolved_authentication_classes
+        .validate()
+        .context(InvalidAuthenticationClassConfigurationSnafu)?;
+
+    let zookeeper_security = ZookeeperSecurity::new(zk, resolved_authentication_classes);
 
     let validated_role_config =
         validated_product_config(zk, &resolved_product_image.product_version, product_config)?;

--- a/rust/operator-binary/src/znode_controller.rs
+++ b/rust/operator-binary/src/znode_controller.rs
@@ -267,7 +267,7 @@ pub async fn reconcile_znode(
                     // block finalizer removal.
                     let zookeeper_security = ZookeeperSecurity::new(
                         &dereferenced.zk,
-                        dereferenced.resolved_authentication_classes.clone(),
+                        dereferenced.authentication_classes.clone(),
                     );
                     reconcile_cleanup(client, dereferenced.zk, &zookeeper_security, &znode_path)
                         .await

--- a/rust/operator-binary/src/znode_controller/dereference.rs
+++ b/rust/operator-binary/src/znode_controller/dereference.rs
@@ -2,7 +2,8 @@
 //!
 //! Fetches the parent [`v1alpha1::ZookeeperCluster`] referenced by the znode's
 //! `spec.clusterRef`, plus the [`ResolvedAuthenticationClasses`] of that cluster. Both Apply
-//! and Cleanup paths in `reconcile_znode` share this output.
+//! and Cleanup paths in `reconcile_znode` share this output. Synchronous validation of the
+//! fetched objects happens in the validate step.
 
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
@@ -32,8 +33,8 @@ pub enum Error {
         zk: ObjectRef<v1alpha1::ZookeeperCluster>,
     },
 
-    #[snafu(display("failed to resolve authentication classes"))]
-    ResolveAuthenticationClasses { source: authentication::Error },
+    #[snafu(display("failed to fetch authentication classes"))]
+    FetchAuthenticationClasses { source: authentication::Error },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -51,12 +52,12 @@ pub async fn dereference(
 ) -> Result<DereferencedObjects> {
     let zk = find_zk_of_znode(client, znode).await?;
 
-    let resolved_authentication_classes = authentication::resolve_authentication_classes(
+    let resolved_authentication_classes = ResolvedAuthenticationClasses::fetch_references(
         client,
         &zk.spec.cluster_config.authentication,
     )
     .await
-    .context(ResolveAuthenticationClassesSnafu)?;
+    .context(FetchAuthenticationClassesSnafu)?;
 
     Ok(DereferencedObjects {
         zk,

--- a/rust/operator-binary/src/znode_controller/dereference.rs
+++ b/rust/operator-binary/src/znode_controller/dereference.rs
@@ -42,7 +42,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// Kubernetes objects referenced from the [`v1alpha1::ZookeeperZnode`] spec, already fetched.
 pub struct DereferencedObjects {
     pub zk: v1alpha1::ZookeeperCluster,
-    pub resolved_authentication_classes: ResolvedAuthenticationClasses,
+    pub authentication_classes: ResolvedAuthenticationClasses,
 }
 
 /// Fetches all Kubernetes objects referenced from the [`v1alpha1::ZookeeperZnode`] spec.
@@ -52,7 +52,7 @@ pub async fn dereference(
 ) -> Result<DereferencedObjects> {
     let zk = find_zk_of_znode(client, znode).await?;
 
-    let resolved_authentication_classes = ResolvedAuthenticationClasses::fetch_references(
+    let authentication_classes = ResolvedAuthenticationClasses::fetch_references(
         client,
         &zk.spec.cluster_config.authentication,
     )
@@ -61,7 +61,7 @@ pub async fn dereference(
 
     Ok(DereferencedObjects {
         zk,
-        resolved_authentication_classes,
+        authentication_classes,
     })
 }
 

--- a/rust/operator-binary/src/znode_controller/dereference.rs
+++ b/rust/operator-binary/src/znode_controller/dereference.rs
@@ -1,7 +1,7 @@
 //! The dereference step in the ZookeeperZnode controller.
 //!
 //! Fetches the parent [`v1alpha1::ZookeeperCluster`] referenced by the znode's
-//! `spec.clusterRef`, plus the [`ResolvedAuthenticationClasses`] of that cluster. Both Apply
+//! `spec.clusterRef`, plus the [`DereferencedAuthenticationClasses`] of that cluster. Both Apply
 //! and Cleanup paths in `reconcile_znode` share this output. Synchronous validation of the
 //! fetched objects happens in the validate step.
 
@@ -12,7 +12,7 @@ use stackable_operator::{
 };
 
 use crate::crd::{
-    authentication::{self, ResolvedAuthenticationClasses},
+    authentication::{self, DereferencedAuthenticationClasses},
     v1alpha1,
 };
 
@@ -42,7 +42,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 /// Kubernetes objects referenced from the [`v1alpha1::ZookeeperZnode`] spec, already fetched.
 pub struct DereferencedObjects {
     pub zk: v1alpha1::ZookeeperCluster,
-    pub authentication_classes: ResolvedAuthenticationClasses,
+    pub authentication_classes: DereferencedAuthenticationClasses,
 }
 
 /// Fetches all Kubernetes objects referenced from the [`v1alpha1::ZookeeperZnode`] spec.
@@ -52,7 +52,7 @@ pub async fn dereference(
 ) -> Result<DereferencedObjects> {
     let zk = find_zk_of_znode(client, znode).await?;
 
-    let authentication_classes = ResolvedAuthenticationClasses::fetch_references(
+    let authentication_classes = DereferencedAuthenticationClasses::fetch_references(
         client,
         &zk.spec.cluster_config.authentication,
     )

--- a/rust/operator-binary/src/znode_controller/validate.rs
+++ b/rust/operator-binary/src/znode_controller/validate.rs
@@ -51,7 +51,7 @@ pub fn validate(
         .context(ResolveProductImageSnafu)?;
 
     let resolved_authentication_classes = dereferenced_objects
-        .resolved_authentication_classes
+        .authentication_classes
         .validate()
         .context(InvalidAuthenticationClassConfigurationSnafu)?;
 

--- a/rust/operator-binary/src/znode_controller/validate.rs
+++ b/rust/operator-binary/src/znode_controller/validate.rs
@@ -10,7 +10,7 @@ use stackable_operator::{
 };
 
 use crate::{
-    crd::{CONTAINER_IMAGE_BASE_NAME, security::ZookeeperSecurity, v1alpha1},
+    crd::{CONTAINER_IMAGE_BASE_NAME, authentication, security::ZookeeperSecurity, v1alpha1},
     znode_controller::dereference::DereferencedObjects,
 };
 
@@ -20,6 +20,9 @@ pub enum Error {
     ResolveProductImage {
         source: product_image_selection::Error,
     },
+
+    #[snafu(display("failed to validate authentication classes"))]
+    InvalidAuthenticationClassConfiguration { source: authentication::Error },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -47,10 +50,13 @@ pub fn validate(
         )
         .context(ResolveProductImageSnafu)?;
 
-    let zookeeper_security = ZookeeperSecurity::new(
-        &dereferenced_objects.zk,
-        dereferenced_objects.resolved_authentication_classes.clone(),
-    );
+    let resolved_authentication_classes = dereferenced_objects
+        .resolved_authentication_classes
+        .validate()
+        .context(InvalidAuthenticationClassConfigurationSnafu)?;
+
+    let zookeeper_security =
+        ZookeeperSecurity::new(&dereferenced_objects.zk, resolved_authentication_classes);
 
     Ok(ValidatedInputs {
         resolved_product_image,


### PR DESCRIPTION
## Description

Follow up for: https://github.com/stackabletech/zookeeper-operator/pull/1034

- split auth class resolve in fetch and validate;

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
