### PR TITLE
chore: Bump ZooKeeper version to 3.9.5 for SDP 26.7.0

### DIFF
--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh
@@ -70,7 +70,7 @@ zkCli_ls() {
 # tag::zkcli-ls[]
 kubectl run my-pod \
   --stdin --tty --quiet --restart=Never \
-  --image oci.stackable.tech/sdp/zookeeper:3.9.4-stackable0.0.0-dev -- \
+  --image oci.stackable.tech/sdp/zookeeper:3.9.5-stackable0.0.0-dev -- \
   bin/zkCli.sh -server simple-zk-server:2282 ls / > /dev/null && \
   kubectl logs my-pod && \
   kubectl delete pods my-pod

--- a/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/getting_started.sh.j2
@@ -70,7 +70,7 @@ zkCli_ls() {
 # tag::zkcli-ls[]
 kubectl run my-pod \
   --stdin --tty --quiet --restart=Never \
-  --image oci.stackable.tech/sdp/zookeeper:3.9.4-stackable{{ versions.zookeeper }} -- \
+  --image oci.stackable.tech/sdp/zookeeper:3.9.5-stackable{{ versions.zookeeper }} -- \
   bin/zkCli.sh -server simple-zk-server:2282 ls / > /dev/null && \
   kubectl logs my-pod && \
   kubectl delete pods my-pod

--- a/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml
+++ b/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
   servers:
     roleConfig:
       listenerClass: cluster-internal

--- a/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
+++ b/docs/modules/zookeeper/examples/getting_started/code/zookeeper.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
   servers:
     roleConfig:
       listenerClass: cluster-internal

--- a/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-authentication.yaml
+++ b/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-authentication.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
   clusterConfig:
     authentication:
       - authenticationClass: zk-client-tls # <1>

--- a/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-encryption.yaml
+++ b/docs/modules/zookeeper/examples/usage_guide/example-cluster-tls-encryption.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
   clusterConfig:
     tls:
       serverSecretClass: tls # <1>

--- a/docs/modules/zookeeper/pages/reference/discovery.adoc
+++ b/docs/modules/zookeeper/pages/reference/discovery.adoc
@@ -26,7 +26,7 @@ The name of the ConfigMap created for this discovery profile is `$BASENAME-nodep
 
 Each discovery profile contains the following fields:
 
-`ZOOKEEPER`:: A connection string, as accepted by https://zookeeper.apache.org/doc/r3.9.4/apidocs/zookeeper-server/org/apache/zookeeper/ZooKeeper.html#ZooKeeper-java.lang.String-int-org.apache.zookeeper.Watcher-[the official Java client], e.g. `test-zk-server-default-0.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282,test-zk-server-default-1.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282/znode-4e169890-d2eb-4d62-9515-e4786f0ac58e`
+`ZOOKEEPER`:: A connection string, as accepted by https://zookeeper.apache.org/doc/r3.9.5/apidocs/zookeeper-server/org/apache/zookeeper/ZooKeeper.html#%3Cinit%3E(java.lang.String,int,org.apache.zookeeper.Watcher)[the official Java client], e.g. `test-zk-server-default-0.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282,test-zk-server-default-1.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282/znode-4e169890-d2eb-4d62-9515-e4786f0ac58e`
 `ZOOKEEPER_HOSTS`:: A comma-separated list of `node1:port1,node2:port2,...`, e.g. `test-zk-server-default-0.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282,test-zk-server-default-1.test-zk-server-default.kuttl-test-proper-spaniel.svc.cluster.local:2282`
 `ZOOKEEPER_CHROOT`:: The name of the root ZNode associated with the discovery profile, should be used if (and only if) connecting using `ZOOKEEPER_HOSTS` (rather than `ZOOKEEPER`), e.g. `/znode-4e169890-d2eb-4d62-9515-e4786f0ac58e` in case of a ZNode discovery or `/` in case of a ZookeeperServer discovery
 `ZOOKEEPER_CLIENT_PORT`:: The port clients should use when connecting, e.g. `2282`

--- a/docs/modules/zookeeper/pages/usage_guide/overrides.adoc
+++ b/docs/modules/zookeeper/pages/usage_guide/overrides.adoc
@@ -39,7 +39,7 @@ servers:
 
 All property values must be strings.
 
-For a full list of configuration options refer to the Apache ZooKeeper https://zookeeper.apache.org/doc/r3.9.4/zookeeperAdmin.html#sc_configuration[Configuration Reference].
+For a full list of configuration options refer to the Apache ZooKeeper https://zookeeper.apache.org/doc/r3.9.5/zookeeperAdmin.html#sc_configuration[Configuration Reference].
 
 === Overriding entries in security.properties
 

--- a/docs/modules/zookeeper/pages/znodes.adoc
+++ b/docs/modules/zookeeper/pages/znodes.adoc
@@ -1,7 +1,7 @@
 = ZNodes
 :description: Manage ZooKeeper ZNodes with the ZookeeperZnode resource. Each client should use a unique root ZNode to prevent conflicts. Network access to ZooKeeper is required.
 
-Apache ZooKeeper organizes all data into a hierarchical system of https://zookeeper.apache.org/doc/r3.9.4/zookeeperProgrammers.html#ch_zkDataModel[ZNodes],
+Apache ZooKeeper organizes all data into a hierarchical system of https://zookeeper.apache.org/doc/r3.9.5/zookeeperProgrammers.html#sc_zkDataModel_znodes,
 which act as both files (they can have data associated with them) and folders (they can contain other ZNodes) when compared to a traditional (POSIX-like) file system.
 
 In order to isolate different clients using the same ZooKeeper cluster, each client application should be assigned a unique root ZNode, which it can then organize

--- a/docs/modules/zookeeper/partials/supported-versions.adoc
+++ b/docs/modules/zookeeper/partials/supported-versions.adoc
@@ -2,4 +2,5 @@
 // This is a separate file, since it is used by both the direct ZooKeeper documentation, and the overarching
 // Stackable Platform documentation.
 
-- 3.9.4 (LTS)
+- 3.9.5 (LTS)
+- 3.9.4 (Deprecated)

--- a/rust/operator-binary/src/config/jvm.rs
+++ b/rust/operator-binary/src/config/jvm.rs
@@ -112,7 +112,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.4"
+            productVersion: "3.9.5"
           servers:
             roleGroups:
               default:
@@ -147,7 +147,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.4"
+            productVersion: "3.9.5"
           servers:
             config:
               resources:

--- a/rust/operator-binary/src/crd/affinity.rs
+++ b/rust/operator-binary/src/crd/affinity.rs
@@ -48,7 +48,7 @@ mod tests {
           name: simple-zk
         spec:
           image:
-            productVersion: 3.9.4
+            productVersion: 3.9.5
           clusterConfig:
             authentication:
               - authenticationClass: zk-client-tls

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -781,7 +781,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.4"
+            productVersion: "3.9.5"
         "#;
         let zookeeper: v1alpha1::ZookeeperCluster =
             serde_yaml::from_str(input).expect("illegal test input");
@@ -801,7 +801,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.4"
+            productVersion: "3.9.5"
           clusterConfig:
             tls:
               serverSecretClass: simple-zookeeper-client-tls
@@ -825,7 +825,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.4"
+            productVersion: "3.9.5"
           clusterConfig:
             tls:
               serverSecretClass: null
@@ -845,7 +845,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.4"
+            productVersion: "3.9.5"
           clusterConfig:
             tls:
               quorumSecretClass: simple-zookeeper-quorum-tls
@@ -871,7 +871,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.4"
+            productVersion: "3.9.5"
         "#;
         let zookeeper: v1alpha1::ZookeeperCluster =
             serde_yaml::from_str(input).expect("illegal test input");
@@ -892,7 +892,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.4"
+            productVersion: "3.9.5"
           clusterConfig:
             tls:
               quorumSecretClass: simple-zookeeper-quorum-tls
@@ -915,7 +915,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.4"
+            productVersion: "3.9.5"
           clusterConfig:
             tls:
               serverSecretClass: simple-zookeeper-server-tls

--- a/rust/operator-binary/src/zk_controller.rs
+++ b/rust/operator-binary/src/zk_controller.rs
@@ -1052,7 +1052,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.4"
+            productVersion: "3.9.5"
           servers:
             roleGroups:
               default:
@@ -1079,7 +1079,7 @@ mod tests {
           name: simple-zookeeper
         spec:
           image:
-            productVersion: "3.9.4"
+            productVersion: "3.9.5"
           servers:
             configOverrides:
               zoo.cfg:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,12 +2,12 @@
 dimensions:
   - name: zookeeper
     values:
-      - 3.9.4
+      - 3.9.5
       # To use a custom image, add a comma and the full name after the product version
       # - x.x.x,oci.stackable.tech/sdp/zookeeper:x.x.x-stackable0.0.0-dev
   - name: zookeeper-latest
     values:
-      - 3.9.4
+      - 3.9.5
       # To use a custom image, add a comma and the full name after the product version
       # - x.x.x,oci.stackable.tech/sdp/zookeeper:x.x.x-stackable0.0.0-dev
   - name: use-server-tls

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,6 +2,7 @@
 dimensions:
   - name: zookeeper
     values:
+      - 3.9.4
       - 3.9.5
       # To use a custom image, add a comma and the full name after the product version
       # - x.x.x,oci.stackable.tech/sdp/zookeeper:x.x.x-stackable0.0.0-dev


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1506.